### PR TITLE
Support for batch operations

### DIFF
--- a/RTable.sln
+++ b/RTable.sln
@@ -24,6 +24,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChainTableInterface", "stab
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "STableLib", "stable\STableLib\STableLib.csproj", "{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "STableUnitTest", "stable\STableUnitTest\STableUnitTest.csproj", "{1CD204E9-2B5D-4015-9B36-17AE0BA7A1EB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1CD204E9-2B5D-4015-9B36-17AE0BA7A1EB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1CD204E9-2B5D-4015-9B36-17AE0BA7A1EB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1CD204E9-2B5D-4015-9B36-17AE0BA7A1EB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1CD204E9-2B5D-4015-9B36-17AE0BA7A1EB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/RTable.sln
+++ b/RTable.sln
@@ -19,6 +19,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E94472
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChainTableFactory", "stable\ChainTableFactory\ChainTableFactory.csproj", "{D34A9308-3F44-4C1C-942E-330BB766EABC}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0F6D71F2-1322-4B32-BB08-A6A99EB812D4} = {0F6D71F2-1322-4B32-BB08-A6A99EB812D4}
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChainTableInterface", "stable\ChainTableInterface\ChainTableInterface.csproj", "{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}"
 EndProject

--- a/RTable.sln
+++ b/RTable.sln
@@ -1,6 +1,8 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
+# Visual Studio 2013
+VisualStudioVersion = 12.0.31101.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConfigurationAgent", "ConfigurationAgent\ConfigurationAgent.csproj", "{3ACBA8E6-4BE4-4858-A618-6F155151757F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Toolkit.Replication", "library\Microsoft.Azure.Toolkit.Replication.csproj", "{0F6D71F2-1322-4B32-BB08-A6A99EB812D4}"
@@ -15,6 +17,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{E94472
 	ProjectSection(SolutionItems) = preProject
 		.nuget\packages.config = .nuget\packages.config
 	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChainTableFactory", "stable\ChainTableFactory\ChainTableFactory.csproj", "{D34A9308-3F44-4C1C-942E-330BB766EABC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ChainTableInterface", "stable\ChainTableInterface\ChainTableInterface.csproj", "{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "STableLib", "stable\STableLib\STableLib.csproj", "{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -42,6 +50,18 @@ Global
 		{86E095D8-ABDC-4CE8-A9DD-39BCFE445FC3}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{86E095D8-ABDC-4CE8-A9DD-39BCFE445FC3}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{86E095D8-ABDC-4CE8-A9DD-39BCFE445FC3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D34A9308-3F44-4C1C-942E-330BB766EABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D34A9308-3F44-4C1C-942E-330BB766EABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D34A9308-3F44-4C1C-942E-330BB766EABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D34A9308-3F44-4C1C-942E-330BB766EABC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/library/ReplicatedTable.cs
+++ b/library/ReplicatedTable.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Toolkit.Replication
     using System.Reflection;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Table;
+    using System.Threading.Tasks;
 
     public class ReplicatedTable : IReplicatedTable
     {
@@ -271,14 +272,18 @@ namespace Microsoft.Azure.Toolkit.Replication
         /// this function will retrieve the row from the specified replica and increment row._rtable_Version.
         /// Finally, (does not matter whether it is in Prepare or Commit phase), create and return an appropriate TableOperation.
         /// The caller of this function will then create a TableBatchOperation based on the return value of this function.
+        /// If needInsertTombstone == true, it will generate the tombstone insert operation and put it to insertTombstones if we need so
         /// </summary>
         /// <param name="row"></param>
         /// <param name="phase"></param>
         /// <param name="index"></param>
+        /// <param name="needInsertTombstone"></param>
+        /// <param name="insertTombstones"></param>
         /// <param name="requestOptions"></param>
         /// <param name="operationContext"></param>
         /// <returns></returns>
-        private TableOperation TransformOp(View txnView, IReplicatedTableEntity row, int phase, int index,
+        private TableOperation TransformOp(View txnView, IReplicatedTableEntity row, int phase, int index, 
+            bool needInsertTombstone, ref TableBatchOperation insertTombstones,
             TableRequestOptions requestOptions = null, OperationContext operationContext = null)
         {
             int tailIndex = txnView.TailIndex;
@@ -325,6 +330,14 @@ namespace Microsoft.Azure.Toolkit.Replication
                                                     row.ETag, currentRow._rtable_Version);
                             return null;
                         }
+
+                        // do not need tombstone
+                        needInsertTombstone = false;
+                    }
+                    else
+                    {
+                        // IOR or IOM, if exists, then not insert tombstone
+                        needInsertTombstone &= (retrievedResult.HttpStatusCode != (int)HttpStatusCode.OK);
                     }
 
                     if (currentRow != null)
@@ -372,23 +385,30 @@ namespace Microsoft.Azure.Toolkit.Replication
                 // We use merge in both phases
                 return TableOperation.Merge(row);
             }
-            else if (row._rtable_Operation == GetTableOperation(TableOperationType.Insert))
+
+            if (needInsertTombstone)
             {
-                // We insert in the prepare phase for non-tail replicas and during the commit phase at the tail replica
-                return TableOperation.Insert(row);
+                DynamicReplicatedTableEntity tsRow = new DynamicReplicatedTableEntity(row.PartitionKey, row.RowKey);
+                tsRow._rtable_RowLock = true;
+                tsRow._rtable_LockAcquisition = DateTime.UtcNow;
+                tsRow._rtable_ViewId = txnView.ViewId;
+                tsRow._rtable_Version = 0;
+                tsRow._rtable_Tombstone = true;
+                tsRow._rtable_Operation = GetTableOperation(TableOperationType.Insert);
+
+                insertTombstones.Add(TableOperation.Insert(tsRow));
             }
-            else if (row._rtable_Operation == GetTableOperation(TableOperationType.InsertOrReplace))
+
+            // we have already inserted tombstone, so replace/merge now
+            row.ETag = "*";
+            if (row._rtable_Operation == GetTableOperation(TableOperationType.InsertOrMerge))
             {
-                return TableOperation.InsertOrReplace(row);
-            }
-            else if (row._rtable_Operation == GetTableOperation(TableOperationType.InsertOrMerge))
-            {
-                return TableOperation.InsertOrMerge(row);
+                return TableOperation.Merge(row);
             }
             else
             {
-                // we shouldn't reach here
-                return null;
+                // insert / IOR
+                return TableOperation.Replace(row);
             }
         }
 
@@ -439,6 +459,8 @@ namespace Microsoft.Azure.Toolkit.Replication
             TableBatchOperation batchOp = new TableBatchOperation();
             IEnumerator<TableResult> iter = (results != null) ? results.GetEnumerator() : null;
             int tailIndex = txnView.TailIndex;
+            bool tombstone = (phase == PREPARE_PHASE && index == txnView.WriteHeadIndex);
+            TableBatchOperation insertTombstone = new TableBatchOperation();
 
             while (enumerator.MoveNext())
             {
@@ -460,7 +482,7 @@ namespace Microsoft.Azure.Toolkit.Replication
                     //          It may be better to check for safety but involves a round trip to the server.
                     row._rtable_BatchId = Guid.NewGuid();
 
-                    if ((prepOp = TransformOp(txnView, row, phase, index, requestOptions, operationContext)) == null)
+                    if ((prepOp = TransformOp(txnView, row, phase, index, tombstone, ref insertTombstone, requestOptions, operationContext)) == null)
                     {
                         return null;
                     }
@@ -477,7 +499,7 @@ namespace Microsoft.Azure.Toolkit.Replication
                     }
                     row._rtable_RowLock = false;
 
-                    if ((prepOp = TransformOp(txnView, row, phase, index, requestOptions, operationContext)) == null)
+                    if ((prepOp = TransformOp(txnView, row, phase, index, tombstone, ref insertTombstone, requestOptions, operationContext)) == null)
                     {
                         throw new ArgumentException();
                     }
@@ -491,6 +513,29 @@ namespace Microsoft.Azure.Toolkit.Replication
 
                 // Add transformed operation to the batch
                 batchOp.Add(prepOp);
+            }
+
+            if (tombstone)
+            {
+                // index == write head
+                // lock head
+                var tableClient = txnView[txnView.WriteHeadIndex];
+                var table = tableClient.GetTableReference(this.TableName);
+
+                if (insertTombstone.Count > 0)
+                {
+                    table.ExecuteBatch(insertTombstone);
+
+                    ValidateTxnView(txnView);
+
+                    // lock rest of the replica
+                    for (int i = 1; i <= tailIndex; ++i)
+                    {
+                        tableClient = txnView[i];
+                        table = tableClient.GetTableReference(this.TableName);
+                        table.ExecuteBatch(insertTombstone);
+                    }
+                }
             }
 
             return batchOp;
@@ -582,7 +627,10 @@ namespace Microsoft.Azure.Toolkit.Replication
             ValidateTxnView(txnView);
 
             // First, make sure all the rows in the batch operation are not locked. If they are locked, flush them.
-            this.FlushAndRetrieveBatch(txnView, batch, requestOptions, null);
+            var oldResults = this.FlushAndRetrieveBatch(txnView, batch, requestOptions, null);
+
+            if (oldResults == null)
+                throw new Exception("something wrong in flush and retrieve");
 
             // Perform the Prepare phase for the headIndex.
             IList<TableResult> headResults = this.RunPreparePhaseAgainstHeadReplica(txnView, batch, requestOptions, operationContext);
@@ -594,7 +642,6 @@ namespace Microsoft.Azure.Toolkit.Replication
             return results[txnView.TailIndex];
         }
 
-
         /// <summary>
         /// Retrieve all the rows in the batchOperation from the headIndex.
         /// Check to see whether any row is locked.
@@ -603,13 +650,30 @@ namespace Microsoft.Azure.Toolkit.Replication
         /// <param name="batch"></param>
         /// <param name="requestOptions"></param>
         /// <param name="operationContext"></param>
-        private void FlushAndRetrieveBatch(
+        private IList<TableResult> FlushAndRetrieveBatch(
             View txnView,
             TableBatchOperation batch,
             TableRequestOptions requestOptions = null,
             OperationContext operationContext = null)
         {
             TableBatchOperation flushBatch = new TableBatchOperation();
+            IList<TableResult> results = new List<TableResult>();
+
+            // TODO: repair them first
+            bool failed = false;
+            Parallel.ForEach(batch, op => {
+                var row = GetEntityFromOperation(op);
+                var repairResult = this.RepairRow(row.PartitionKey, row.RowKey, null);
+                if (repairResult == null)
+                {
+                    // service unavailable
+                    failed = true;
+                }
+            });
+            if (failed)
+            {
+                return null;
+            }
 
             IEnumerator<TableOperation> enumerator = batch.GetEnumerator();
             while (enumerator.MoveNext())
@@ -624,12 +688,9 @@ namespace Microsoft.Azure.Toolkit.Replication
                 if (retrievedResult == null)
                 {
                     // service unavailable
+                    return null;
                 }
-                else if (retrievedResult.Result == null)
-                {
-                    // row may not be present
-                }
-                else if (retrievedResult.HttpStatusCode == (int)HttpStatusCode.OK)
+                else if (retrievedResult.HttpStatusCode == (int)HttpStatusCode.OK && retrievedResult.Result != null)
                 {
                     IReplicatedTableEntity currentRow = ConvertToIReplicatedTableEntity(retrievedResult);
 
@@ -641,25 +702,38 @@ namespace Microsoft.Azure.Toolkit.Replication
                             {
                                 ReplicatedTableLogger.LogInformational("FlushAndRetrieveBatch(): Row is locked and has expired. PartitionKey={0} RowKey={1}",
                                                         row.PartitionKey, row.RowKey);
-                                this.Flush2PC(txnView, currentRow, requestOptions, operationContext);
+                                var result = this.Flush2PC(txnView, currentRow, requestOptions, operationContext);
+                                if (result == null ||
+                                    (result.HttpStatusCode != (int)HttpStatusCode.OK && result.HttpStatusCode != (int)HttpStatusCode.NoContent))
+                                    return null;
+                                results.Add(result);
                             }
                             catch (Exception ex)
                             {
                                 ReplicatedTableLogger.LogError("FlushAndRetrieveBatch(): Flush2PC() exception {0}", ex.ToString());
+                                return null;
                             }
                         }
                         else
                         {
                             ReplicatedTableLogger.LogInformational("FlushAndRetrieveBatch(): Row is locked but NOT expired. PartitionKey={1} RowKey={1}",
                                                     row.PartitionKey, row.RowKey);
+                            return null;
                         }
+                    }
+                    else
+                    {
+                        results.Add(retrievedResult);
                     }
                 }
                 else
                 {
                     // row may not be present
+                    results.Add(new TableResult() { HttpStatusCode = (int) HttpStatusCode.NotFound, Etag = null, Result = null });
                 }
             }
+
+            return results;
         }
 
         /// <summary>
@@ -681,6 +755,8 @@ namespace Microsoft.Azure.Toolkit.Replication
 
             CloudTableClient tableClient = txnView[txnView.WriteHeadIndex];
             CloudTable table = tableClient.GetTableReference(this.TableName);
+
+            // insert tombstone when transform
             TableBatchOperation batchOp = TransformUpdateBatchOp(txnView, batch, phase, txnView.WriteHeadIndex, null, requestOptions,
                 operationContext);
             if (batchOp == null)

--- a/library/ReplicatedTable.cs
+++ b/library/ReplicatedTable.cs
@@ -535,7 +535,7 @@ namespace Microsoft.Azure.Toolkit.Replication
                     }
 
                     // lock rest of the replica
-                    for (int i = 1; i <= tailIndex; ++i)
+                    for (int i = txnView.WriteHeadIndex+1; i <= txnView.TailIndex; ++i)
                     {
                         tableClient = txnView[i];
                         table = tableClient.GetTableReference(this.TableName);

--- a/stable/ChainTableFactory/ATableAdapter.cs
+++ b/stable/ChainTableFactory/ATableAdapter.cs
@@ -1,0 +1,77 @@
+﻿using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.ChainTableFactory
+{
+    class ATableAdapter : IChainTable
+    {
+        // This Adapter adapts a normal Azure Table (ATable) to the IComposableTable interface.
+
+        public ATableAdapter(CloudTable table)
+        {
+            this.table = table;
+        }
+
+        public Table.TableResult Execute(Table.TableOperation operation, Table.TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            var res = table.Execute(operation, requestOptions, operationContext);
+            return res;
+        }
+
+        public IList<Table.TableResult> ExecuteBatch(Table.TableBatchOperation batch, Table.TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            try
+            {
+                return table.ExecuteBatch(batch, requestOptions, operationContext);
+            }
+            catch (StorageException e)
+            {
+                // find the error index
+                // WARNING: this is not very reliable
+                // c.f. http://stackoverflow.com/questions/14282385/azure-cloudtable-executebatchtablebatchoperation-throws-a-storageexception-ho/14290910#14290910
+                var msg = e.RequestInformation.ExtendedErrorInformation.ErrorMessage;
+                var parts = msg.Split(':');
+                var errorIndex = int.Parse(parts[0]);
+
+                throw new ChainTableInterface.ChainTableBatchException(errorIndex, e);
+            }
+        }
+
+        public Task<Table.TableResult> ExecuteAsync(Table.TableOperation operation, Table.TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            return table.ExecuteAsync(operation, requestOptions, operationContext);
+        }
+
+
+
+        private CloudTable table;
+
+
+        public string GetTableID()
+        {
+            return table.Name;
+        }
+
+
+        public bool CreateIfNotExists()
+        {
+            return table.CreateIfNotExists();
+        }
+
+        public bool DeleteIfExists()
+        {
+            return table.DeleteIfExists();
+        }
+
+
+        public IEnumerable<T> ExecuteQuery<T>(TableQuery<T> q) where T : ITableEntity, new()
+        {
+            return table.ExecuteQuery<T>(q);
+        }
+    }
+}

--- a/stable/ChainTableFactory/App.config
+++ b/stable/ChainTableFactory/App.config
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/stable/ChainTableFactory/ChainTableFactory.csproj
+++ b/stable/ChainTableFactory/ChainTableFactory.csproj
@@ -40,7 +40,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.Azure.Toolkit.Replication">
-      <HintPath>..\library\obj\Debug\Microsoft.Azure.Toolkit.Replication.dll</HintPath>
+      <HintPath>..\..\library\bin\Release\Microsoft.Azure.Toolkit.Replication.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
@@ -89,6 +89,9 @@
       <Project>{c24bc418-9bfd-48fa-94be-8dc8864c2ea6}</Project>
       <Name>ChainTableInterface</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <WCFMetadata Include="Service References\" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/stable/ChainTableFactory/ChainTableFactory.csproj
+++ b/stable/ChainTableFactory/ChainTableFactory.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{D34A9308-3F44-4C1C-942E-330BB766EABC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ChainTableFactory</RootNamespace>
+    <AssemblyName>ChainTableFactory</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Toolkit.Replication">
+      <HintPath>..\library\obj\Debug\Microsoft.Azure.Toolkit.Replication.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.6.1.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ATableAdapter.cs" />
+    <Compile Include="DefaultChainTableService.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RTableAdapter.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ChainTableInterface\ChainTableInterface.csproj">
+      <Project>{c24bc418-9bfd-48fa-94be-8dc8864c2ea6}</Project>
+      <Name>ChainTableInterface</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/stable/ChainTableFactory/DefaultChainTableService.cs
+++ b/stable/ChainTableFactory/DefaultChainTableService.cs
@@ -1,0 +1,98 @@
+﻿using Microsoft.Azure.Toolkit.Replication;
+using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.WindowsAzure.Storage.RTable;
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.ChainTableFactory
+{
+    using System.IO;
+
+    public class DefaultChainTableService : IChainTableService
+    {
+        public DefaultChainTableService(string configFile)
+        {
+            this.configFileName = configFile;
+            StreamReader fs = File.OpenText(configFileName);
+            string line = fs.ReadLine();
+
+            rTabConfLocs = new List<ConfigurationStoreLocationInfo>();
+            rTabDataChain = new List<ReplicaInfo>();
+
+            bool first = true;
+            while (!fs.EndOfStream)
+            {
+                line = fs.ReadLine();
+                string[] tokens = line.Split();
+                string accountName = tokens[0];
+                string accountKey = tokens[1];
+
+                string connStr = String.Format("DefaultEndpointsProtocol=https;AccountName={0};AccountKey={1}", accountName, accountKey);
+                if (first)
+                {
+                    first = false;
+                    csa = CloudStorageAccount.Parse(connStr);
+                    client = csa.CreateCloudTableClient();
+                    rTabConfLocs.Add(new ConfigurationStoreLocationInfo() {
+                        StorageAccountName = accountName,
+                        StorageAccountKey = accountKey,
+                        BlobPath = Constants.RTableConfigurationBlobLocationContainerName + "/myRTableConfig1"
+                    });
+                }
+
+                rTabDataChain.Add(new ReplicaInfo() {
+                    StorageAccountName = accountName,
+                    StorageAccountKey = accountKey
+                });
+            }
+
+            ReplicatedTableConfigurationService rtableConfig = new ReplicatedTableConfigurationService(rTabConfLocs, true);
+            rtableConfig.UpdateConfiguration(rTabDataChain, 0);
+
+            fs.Close();
+        }
+
+        public DefaultChainTableService(ReplicatedTableConfigurationService rtableConfigV2)
+        {
+            this.rtableConfigV2 = rtableConfigV2;
+        }
+
+        public IChainTable GetChainTable(string tableId)
+        {
+            if (rtableConfigV2 != null)
+            {
+                var name = tableId.Substring(9);
+                ReplicatedTable rTable = new ReplicatedTable(name, rtableConfigV2);
+                return new RTableAdapter(rTable);
+            }
+
+            if (tableId.StartsWith("__RTable_"))
+            {
+                var name = tableId.Substring(9);
+                ReplicatedTableConfigurationService rtableConfig = new ReplicatedTableConfigurationService(rTabConfLocs, true);
+                ReplicatedTable rTable = new ReplicatedTable(name, rtableConfig);
+                return new RTableAdapter(rTable);
+            }
+            else
+                return new ATableAdapter(client.GetTableReference(tableId));
+        }
+
+        private string configFileName;
+        private CloudStorageAccount csa;
+        private CloudTableClient client;
+
+        private List<ConfigurationStoreLocationInfo> rTabConfLocs;
+        private List<ReplicaInfo> rTabDataChain;
+
+        private ReplicatedTableConfigurationService rtableConfigV2 = null;
+
+        public string Serialize()
+        {
+            return configFileName;
+        }
+    }
+}

--- a/stable/ChainTableFactory/Properties/AssemblyInfo.cs
+++ b/stable/ChainTableFactory/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ChainTableFactory")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ChainTableFactory")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("97a1d9a6-bba9-4ed1-9700-7c245388ccad")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/stable/ChainTableFactory/RTableAdapter.cs
+++ b/stable/ChainTableFactory/RTableAdapter.cs
@@ -1,0 +1,339 @@
+﻿//#define RPERF
+
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using System.Net;
+using System.Diagnostics;
+using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.Azure.Toolkit.Replication;
+
+namespace Microsoft.WindowsAzure.Storage.RTable
+{
+    class RTableAdapter : IChainTable
+    {
+        public RTableAdapter(ReplicatedTable rtable)
+        {
+            this.rtable = rtable;
+        }
+
+        public TableResult Execute(TableOperation operation,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            var oldOp = operation;
+
+            // Encapsulate
+            operation = EncapsulateOp(oldOp, operationContext);
+
+            // Execute
+
+            var res = rtable.Execute(operation, requestOptions, operationContext);
+
+
+            // Currently RTable do not throw exception on error, so we throw it...
+            var opType = GetOpType(oldOp);
+
+            // the published rtable returns 204 for insert
+            if (opType == TableOperationType.Insert && res.HttpStatusCode == (int)HttpStatusCode.NoContent)
+                res.HttpStatusCode = (int)HttpStatusCode.Created;
+            // the published rtable returns 409 for precondition failure on merge / replace / delete
+            if ((opType == TableOperationType.Merge || opType == TableOperationType.Replace || opType == TableOperationType.Delete)
+                && res.HttpStatusCode == (int)HttpStatusCode.Conflict)
+                res.HttpStatusCode = (int)HttpStatusCode.PreconditionFailed;
+
+            if (
+                (opType == TableOperationType.Insert && res.HttpStatusCode != (int)HttpStatusCode.Created) ||
+                (opType == TableOperationType.Replace && res.HttpStatusCode != (int)HttpStatusCode.NoContent) ||
+                (opType == TableOperationType.Merge && res.HttpStatusCode != (int)HttpStatusCode.NoContent) ||
+                (opType == TableOperationType.InsertOrReplace && res.HttpStatusCode != (int)HttpStatusCode.NoContent) ||
+                (opType == TableOperationType.InsertOrMerge && res.HttpStatusCode != (int)HttpStatusCode.NoContent) ||
+                (opType == TableOperationType.Delete && res.HttpStatusCode != (int)HttpStatusCode.NoContent) ||
+                (opType == TableOperationType.Retrieve && res.HttpStatusCode != (int)HttpStatusCode.OK && res.HttpStatusCode != (int)HttpStatusCode.NotFound)
+                )
+            {
+                // throw an exception...
+                var reqres = new RequestResult();
+                reqres.HttpStatusCode = res.HttpStatusCode;
+                var ex = new StorageException(reqres, null, null);
+
+                throw ex;
+            }
+
+            // Decapsulate
+            Decapsulate(res, oldOp, operationContext);
+
+            return res;
+        }
+
+              
+        public IList<TableResult> ExecuteBatch(TableBatchOperation batch,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            TableBatchOperation newBatch = new TableBatchOperation();
+            List<TableOperation> opList = new List<TableOperation>();
+            foreach (var op in batch)
+            {
+                opList.Add(op);
+                newBatch.Add(EncapsulateOp(op, operationContext));
+            }
+
+            try
+            {
+                var res = rtable.ExecuteBatch(newBatch, requestOptions, operationContext);
+
+                for (int i = 0; i < res.Count; ++i)
+                {
+                    Decapsulate(res[i], opList[i], operationContext);
+                }
+
+                return res;
+            }
+            catch (StorageException ex)
+            {
+                int errorIndex = 0;
+
+                // Currently RTable does not return failed index, always set to 0
+
+                /*
+                if (batch.Count > 1)
+                {
+                    try
+                    {
+                        throw new ChainTableBatchException(0, ex);
+                        // find the error index
+                        // WARNING: this is not very reliable
+                        // c.f. http://stackoverflow.com/questions/14282385/azure-cloudtable-executebatchtablebatchoperation-throws-a-storageexception-ho/14290910#14290910
+                        var msg = ex.RequestInformation.ExtendedErrorInformation.ErrorMessage;
+                        var parts = msg.Split(':');
+                        errorIndex = int.Parse(parts[0]);
+                    }
+                    catch (Exception)
+                    {
+                        // ignore, just say errorIndex = 0
+                    }
+                }
+                */
+
+                // change RTableConflictException to a standard StorageException with httpcode = conflict
+                if (ex is ReplicatedTableConflictException)
+                {
+                    RequestResult res = new RequestResult();
+                    res.HttpStatusCode = (int)HttpStatusCode.Conflict;
+                    ex = new StorageException(res, "RTable conflict exception", null);
+                }
+
+                throw new ChainTableInterface.ChainTableBatchException(errorIndex, ex);
+            }           
+        }
+        
+
+        public Task<TableResult> ExecuteAsync(TableOperation operation,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            // WARNING:
+            // KNOWN ISSUE: if the user changes the entity in operation immediately after executeAsync, there is a race
+            // that the operation may be done with the new entity.
+            // Consider clone the operation before returning from ExecuteAsync
+            // One caveat: the returned TableResult.Result should point to the same object as the one in request...
+
+            // KNOWN ISSUE: if the user changes the entity in operation later than Encapsulate during Execute, but before
+            // Decapsulate, the operation will be done with the old entity, and Decapsulate will overwrite the user-changed
+            // entity back to the old version
+
+            var handle = Task.Factory.StartNew<TableResult>(() => Execute(operation, requestOptions, operationContext));
+            return handle;
+        }
+
+        private TableOperation EncapsulateOp(TableOperation oldOp, OperationContext operationContext)
+        {
+            TableOperation result = null;
+            var opType = GetOpType(oldOp);
+            // Encapsulate
+            if (opType == TableOperationType.Insert
+                || opType == TableOperationType.Replace
+                || opType == TableOperationType.Merge
+                || opType == TableOperationType.InsertOrReplace
+                || opType == TableOperationType.InsertOrMerge
+                || opType == TableOperationType.Delete)
+            {
+                // encapsulate user's argument
+                var row = GetEntityFromOperation(oldOp);
+                DynamicReplicatedTableEntity encapsulatedRow =
+                    new DynamicReplicatedTableEntity(row.PartitionKey, row.RowKey, row.ETag, row.WriteEntity(operationContext));
+
+                if (opType == TableOperationType.Insert)
+                    result = TableOperation.Insert(encapsulatedRow, true);
+                else if (opType == TableOperationType.Replace)
+                    result = TableOperation.Replace(encapsulatedRow);
+                else if (opType == TableOperationType.Merge)
+                    result = TableOperation.Merge(encapsulatedRow);
+                else if (opType == TableOperationType.InsertOrReplace)
+                    result = TableOperation.InsertOrReplace(encapsulatedRow);
+                else if (opType == TableOperationType.InsertOrMerge)
+                    result = TableOperation.InsertOrMerge(encapsulatedRow);
+                else if (opType == TableOperationType.Delete)
+                    result = TableOperation.Delete(encapsulatedRow);
+            }
+            else if (opType == TableOperationType.Retrieve)
+            {
+                var pKey = GetPartitionKeyFromOperation(oldOp);
+                var rKey = GetRowKeyFromOperation(oldOp);
+                result = TableOperation.Retrieve<DynamicReplicatedTableEntity>(pKey, rKey);
+            }
+
+            return result;
+        }
+
+        private void Decapsulate(TableResult res, TableOperation oldOp, OperationContext operationContext)
+        {
+            if (res.Result != null)
+            {
+                if (!(res.Result is DynamicReplicatedTableEntity))
+                    throw new Exception("SHOULD NOT HAPPEN");
+
+                var opType = GetOpType(oldOp);
+                var result = (DynamicReplicatedTableEntity)res.Result;
+                if (opType == TableOperationType.Retrieve)
+                {
+                    // For retrieve, we need to construct a new user-defined type using reflection
+                    var resolverField = oldOp.GetType().GetField("retrieveResolver", BindingFlags.Instance | BindingFlags.NonPublic);
+                    var resolver = (Func<string, string, DateTimeOffset, IDictionary<string, EntityProperty>, System.String, System.Object>)
+                        resolverField.GetValue(oldOp);
+
+                    var newRes = (ITableEntity)resolver.Invoke(result.PartitionKey, result.RowKey, result.Timestamp, result.Properties, result.ETag);
+                    res.Result = newRes;
+                }
+                else
+                {
+                    var row = GetEntityFromOperation(oldOp);
+
+                    row.PartitionKey = result.PartitionKey;
+                    row.RowKey = result.RowKey;
+                    row.ETag = result.ETag;
+                    row.Timestamp = result.Timestamp;
+                    row.ReadEntity(result.Properties, operationContext);
+
+                    res.Result = row;
+                }
+            }
+        }
+
+        private TableOperationType GetOpType(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields in WindowsAzureStorage dll
+            PropertyInfo opType = operation.GetType().GetProperty("OperationType", System.Reflection.BindingFlags.GetProperty |
+                                                               System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            TableOperationType opTypeValue = (TableOperationType)(opType.GetValue(operation, null));
+
+            return opTypeValue;
+        }
+
+        private ITableEntity GetEntityFromOperation(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("Entity", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return (ITableEntity)(entity.GetValue(operation, null));
+        }
+
+        private string GetPartitionKeyFromOperation(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("RetrievePartitionKey", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return (string)(entity.GetValue(operation, null));
+        }
+
+        private string GetRowKeyFromOperation(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("RetrieveRowKey", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return (string)(entity.GetValue(operation, null));
+        }
+
+        private void SetEntityInOperation(TableOperation operation, DynamicReplicatedTableEntity encapsulatedRow)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("Entity", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            entity.SetValue(operation, encapsulatedRow);
+        }
+
+
+        private ReplicatedTable rtable;
+
+
+        public string GetTableID()
+        {
+            return "__RTable_" + rtable.TableName;
+        }
+
+
+        public bool CreateIfNotExists()
+        {
+            return rtable.CreateIfNotExists();
+        }
+
+        public bool DeleteIfExists()
+        {
+            return rtable.DeleteIfExists();
+        }
+
+
+        public IEnumerable<TElement> ExecuteQuery<TElement>(TableQuery<TElement> q) where TElement : ITableEntity, new()
+        {
+            TableQuery<DynamicReplicatedTableEntity> encapedQuery = new TableQuery<DynamicReplicatedTableEntity>();
+            encapedQuery.FilterString = q.FilterString;
+            encapedQuery.SelectColumns = q.SelectColumns;
+
+            if (encapedQuery.SelectColumns != null)
+            {
+                // should at least contain rtable's metadata
+                encapedQuery.SelectColumns.Add("_rtable_RowLock");
+                encapedQuery.SelectColumns.Add("_rtable_Version");
+                encapedQuery.SelectColumns.Add("_rtable_Tombstone");
+                encapedQuery.SelectColumns.Add("_rtable_ViewId");
+                encapedQuery.SelectColumns.Add("_rtable_Operation");
+                encapedQuery.SelectColumns.Add("_rtable_BatchId");
+                encapedQuery.SelectColumns.Add("_rtable_LockAcquisition");
+            }
+            encapedQuery.TakeCount = q.TakeCount;
+
+            var rawres = rtable.ExecuteQuery(encapedQuery);
+
+            var res = from rawEnt in rawres
+                      select DecapsulateEnt<TElement>(rawEnt);
+
+            return res;
+        }
+
+        private TElement DecapsulateEnt<TElement>(DynamicReplicatedTableEntity rawEnt) where TElement : ITableEntity, new()
+        {
+            // For retrieve, we need to construct a new user-defined type using reflection
+            var retOp = TableOperation.Retrieve<TElement>("1", "1");
+            var resolverField = retOp.GetType().GetField("retrieveResolver", BindingFlags.Instance | BindingFlags.NonPublic);
+            var resolver = (Func<string, string, DateTimeOffset, IDictionary<string, EntityProperty>, System.String, System.Object>)
+                resolverField.GetValue(retOp);
+
+            // RTable's query interface forgot to virtualize etag, so we virtualize it here
+            // i.e., use Version.toString() rather than rawEnt.ETag, c.f., Decapsulate()
+            var newEnt = (TElement)resolver.Invoke(rawEnt.PartitionKey, rawEnt.RowKey, rawEnt.Timestamp, rawEnt.Properties, rawEnt._rtable_Version.ToString());
+            return newEnt;
+        }
+    }
+}

--- a/stable/ChainTableFactory/packages.config
+++ b/stable/ChainTableFactory/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />
+</packages>

--- a/stable/ChainTableInterface/App.config
+++ b/stable/ChainTableInterface/App.config
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+    </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/stable/ChainTableInterface/ChainTableBatchException.cs
+++ b/stable/ChainTableInterface/ChainTableBatchException.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.WindowsAzure.Storage;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.ChainTableInterface
+{
+    public class ChainTableBatchException : StorageException
+    {
+        public int FailedOpIndex { get; private set; }
+
+        public ChainTableBatchException(int failedOpIndex, StorageException storageEx)
+            : base(storageEx.RequestInformation, storageEx.Message, storageEx.InnerException)
+        {
+            this.FailedOpIndex = failedOpIndex;
+        }
+    }
+}

--- a/stable/ChainTableInterface/ChainTableInterface.csproj
+++ b/stable/ChainTableInterface/ChainTableInterface.csproj
@@ -1,0 +1,92 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{C24BC418-9BFD-48FA-94BE-8DC8864C2EA6}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>ChainTableInterface</RootNamespace>
+    <AssemblyName>ChainTableInterface</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <StartupObject />
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.6.1.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ChainTableBatchException.cs" />
+    <Compile Include="IChainTable.cs" />
+    <Compile Include="IChainTableService.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/stable/ChainTableInterface/IChainTable.cs
+++ b/stable/ChainTableInterface/IChainTable.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.ChainTableInterface
+{
+    // Any storage implementation that implements IChainTable can be used in TxTable
+    public interface IChainTable
+    {
+        /*
+         * Execute API:
+         *   (1) Retrieve
+         *          On success, return TableResult, code = 200 (OK);
+         *          If the row does not exist, return TableResult, code = 404 (NotFound);
+         *          Otherwise, throw storage exception with corresponding http error code.
+         *   (2) Insert
+         *          On success, return TableResult, code = 201 (Created);
+         *          If the row already exists, throw storage exception, code = 409 (Conflict);
+         *          Otherwise, throw storage exception with corresponding http error code.
+         *   (3) Replace / Merge / Delete
+         *          On success, return TableResult, code = 204 (NoContent);
+         *          If the row does not exist, throw storage exception, code = 404 (NotFound);
+         *          If ETag mismatches, throw storage exception, code = 412 (Precondition);
+         *          Otherwise, throw storage exception with corresponding http error code.
+         *   (4) InsertOrReplace / InsertOrMerge
+         *          On success, return TableResult, code = 204 (NoContent);
+         *          Otherwise, throw storage exception with corresponding http error code.
+         */         
+        TableResult Execute(TableOperation operation,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null);
+
+        /*
+         * Batch Execute API:
+         *   Caller should not put retrieve operations inside a batch, so any error will lead to
+         *   an Exception.
+         *   
+         *   On success, return a list of TableResult. Each TableResult should follow the API
+         *   defined in Execute operation.
+         *   
+         *   Otherwise, throw a ChainTableBatchException, with failedOpIndex marks to the first
+         *   operation that causes the failure, and storageEx being the corresponding exception
+         *   defined in the Execute API.
+         */
+        IList<TableResult> ExecuteBatch(TableBatchOperation batch,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null);
+
+        Task<TableResult> ExecuteAsync(TableOperation operation,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null);
+
+
+        /*
+         * Query interface:
+         */
+        IEnumerable<TElement> ExecuteQuery<TElement>(TableQuery<TElement> q) where TElement : ITableEntity, new();
+
+        string GetTableID();
+
+        bool CreateIfNotExists();
+
+        bool DeleteIfExists();
+
+        // Should add ExecuteQuery Interface?
+    }
+}

--- a/stable/ChainTableInterface/IChainTableService.cs
+++ b/stable/ChainTableInterface/IChainTableService.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.ChainTableInterface
+{
+    public interface IChainTableService
+    {
+        // Translate a Kiwi table identity to a Kiwi table
+        IChainTable GetChainTable(string tableId);
+
+        // serialize the parameter for this table servicce
+        string Serialize();
+    }
+}

--- a/stable/ChainTableInterface/Properties/AssemblyInfo.cs
+++ b/stable/ChainTableInterface/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("ChainTableInterface")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("ChainTableInterface")]
+[assembly: AssemblyCopyright("Copyright ©  2014")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("cd7adab1-a08a-4cb1-b41e-1bd69632ce4c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/stable/ChainTableInterface/packages.config
+++ b/stable/ChainTableInterface/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />
+</packages>

--- a/stable/STableLib/DefaultSTableConfig.cs
+++ b/stable/STableLib/DefaultSTableConfig.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    public class DefaultSTableConfig : ISTableConfig
+    {
+        public DefaultSTableConfig(string sTableName, bool useRTable)
+        {
+            this.namebase = sTableName;
+            this.useRTable = useRTable;
+        }
+
+        public string GetHeadTableId()
+        {
+            var prefix = useRTable ? "__RTable_" : "";
+            return prefix + namebase;
+        }
+
+        public string GetSnapshotTableId(int ssid)
+        {
+            var prefix = useRTable ? "__RTable_" : "";
+            return prefix + namebase + "SSTab" + ssid;
+        }
+
+        private string namebase;
+        private bool useRTable;
+    }
+}

--- a/stable/STableLib/ISTableConfig.cs
+++ b/stable/STableLib/ISTableConfig.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    public interface ISTableConfig
+    {
+        string GetHeadTableId();
+
+        string GetSnapshotTableId(int ssid);
+    }
+}

--- a/stable/STableLib/Microsoft.Azure.Toolkit.Snapshots.csproj
+++ b/stable/STableLib/Microsoft.Azure.Toolkit.Snapshots.csproj
@@ -1,0 +1,84 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>STableLib</RootNamespace>
+    <AssemblyName>STableLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.2.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.2.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage">
+      <HintPath>..\..\packages\WindowsAzure.Storage.2.1.0.3\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Spatial.5.2.0\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="STableEntity.cs" />
+    <Compile Include="DefaultSTableConfig.cs" />
+    <Compile Include="STable.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ISTableConfig.cs" />
+    <Compile Include="STableHistoryInfo.cs" />
+    <Compile Include="STableMetadataEntity.cs" />
+    <Compile Include="StorageLayer.cs" />
+    <Compile Include="TableService.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ChainTableInterface\ChainTableInterface.csproj">
+      <Project>{c24bc418-9bfd-48fa-94be-8dc8864c2ea6}</Project>
+      <Name>ChainTableInterface</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/stable/STableLib/Properties/AssemblyInfo.cs
+++ b/stable/STableLib/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("STableLib")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("STableLib")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("80abff3e-534e-4a04-bf2c-44764a2a2035")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/stable/STableLib/STable.cs
+++ b/stable/STableLib/STable.cs
@@ -1,0 +1,1683 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    public class STable : IChainTable
+    {
+        public string TableName { get; private set; }
+
+        public STable(string tableName, ISTableConfig config, IChainTableService cts)
+        {
+            TableName = tableName;
+            this.ts = new TableService(config, cts);
+        }
+
+
+        // Table management
+
+        public bool CreateIfNotExists()
+        {
+            IChainTable headTable = ts.GetHead();
+            if (!headTable.CreateIfNotExists())
+                return false;
+
+            var meta = new STableMetadataEntity();
+
+            var res = StorageLayer.ModifyRow(headTable, TableOperationType.Insert, meta, null);
+            if (res == null || res.HttpStatusCode != (int)HttpStatusCode.Created)
+                return false;
+
+            return true;
+
+        }
+
+        public bool DeleteIfExists()
+        {
+            IChainTable headTable = ts.GetHead();
+
+            var metaRes = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+
+            if (metaRes != null && metaRes.HttpStatusCode == (int)HttpStatusCode.OK && metaRes.Result != null)
+            {
+                var metaBlock = (STableMetadataEntity)metaRes.Result;
+                int ssid = metaBlock.CurrentSSID;
+                for (int i = 0; i < metaBlock.CurrentSSID; ++i)
+                {
+                    var snapshot = ts.GetSnapshot(i);
+                    snapshot.DeleteIfExists();
+                }
+
+                headTable.DeleteIfExists();
+                return true;
+            }
+            else
+                return false;
+        }
+
+
+        // Operation API
+
+        // standard operation
+        public TableResult Execute(TableOperation operation, TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            if (operation == null)
+                throw new ArgumentNullException();
+
+            TableOperationType opType = GetOpType(operation);
+            if (opType == TableOperationType.Retrieve)
+                return HandleRetrieve(operation, requestOptions, operationContext);
+            else if (opType == TableOperationType.Insert)
+                return HandleInsert(operation, requestOptions, operationContext);
+            else if (opType == TableOperationType.Replace || opType == TableOperationType.Merge || opType == TableOperationType.Delete)
+                return HandleModify(operation, requestOptions, operationContext);
+            else if (opType == TableOperationType.InsertOrMerge || opType == TableOperationType.InsertOrReplace)
+                return HandleIOX(operation, requestOptions, operationContext);
+            else
+                throw new Exception("Unknown operation type: " + opType);
+        }
+
+        // added operation: read history
+        public TableResult RetrieveFromSnapshot(TableOperation operation, int snapshotId, TableRequestOptions options = null, OperationContext context = null)
+        {
+            return HandleRetrieveFromSnapshot(operation, snapshotId, options, context);
+        }
+
+
+        // Batch API
+
+        public IList<TableResult> ExecuteBatch(TableBatchOperation batch, TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            return HandleExecuteBatch(batch, requestOptions, operationContext);
+        }
+
+
+        // Async API, naive impl.
+
+        public Task<TableResult> ExecuteAsync(TableOperation operation, TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            var handle = Task.Factory.StartNew<TableResult>(() => Execute(operation, requestOptions, operationContext));
+            return handle;
+        }
+
+
+        // Query API
+        public IEnumerable<TElement> ExecuteQuery<TElement>(TableQuery<TElement> q) where TElement : ITableEntity, new()
+        {
+            return HandleExecuteQuery<TElement>(q);
+        }
+
+
+        // Snapshot management
+
+        // return all the history information of this STable
+        public STableHistoryInfo GetSTableHistory()
+        {
+            return HandleGetSTableHistory();
+        }
+
+        // Return: snapshot Id
+        public int CreateSnapshot()
+        {
+            return HandleCreateSnapshot(-1).CurrentSSID - 1;
+        }
+
+        public void DeleteSnapshot(int snapshotId)
+        {
+            HandleDeleteSnapshot(snapshotId);
+        }
+        public IList<int> ListValidSnapshots()
+        {
+            return HandleListValidSnapshots();
+        }
+
+        // Return: the created snapshot containing the system state before rollback
+        public int Rollback(int snapshotId)
+        {
+            return HandleRollback(snapshotId);
+        }
+
+
+        // Garbage Collection
+
+        public void GC()
+        {
+            HandleGC();
+        }
+
+
+        // For IChainTable interface
+
+        // TableID is used by IChainTableFactory, which is transparent to user
+        // User only care about TableName
+        public string GetTableID()
+        {
+            return "__STable_" + TableName;
+        }
+
+
+
+        // private members
+        private TableService ts = null;
+        private Random random = new Random();
+
+
+
+        // Single-row operations, including RetrieveFromSnapshot
+
+        // Retrieve the latest version of a row
+        private TableResult HandleRetrieve(TableOperation operation, TableRequestOptions options, OperationContext context)
+        {
+            // get parameters
+            var partitionKey = GetPartitionKeyFromOperation(operation);
+            var rowKey = GetRowKeyFromOperation(operation);
+
+            // retrieve can be executed directly, throw any exception
+            var headTable = ts.GetHead();
+            var response = StorageLayer.RetrieveRow(headTable, TableOperation.Retrieve<STableEntity>(partitionKey, rowKey), options, context);
+
+            // handle result
+            if (response == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            else if (response.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                return response;
+            else if (response.HttpStatusCode == (int)HttpStatusCode.OK && response.Result != null)
+            {
+                var rawData = (STableEntity)response.Result;
+
+                // check delete bit, construct response
+                var ret = new TableResult();
+                if (rawData.Deleted)
+                {
+                    ret.HttpStatusCode = (int)HttpStatusCode.NotFound;
+                    ret.Result = null;
+                    ret.Etag = null;
+                }
+                else
+                {
+                    ret.Etag = rawData.VETag;
+                    ret.HttpStatusCode = response.HttpStatusCode;
+                    ret.Result = Decapsulate(rawData, operation);
+                }
+                return ret;
+            }
+            else
+                throw GenerateException((HttpStatusCode)response.HttpStatusCode);
+        }
+
+        private TableResult HandleInsert(TableOperation operation, TableRequestOptions options, OperationContext context)
+        {
+            // get parameters
+            var userArg = GetEntityFromOperation(operation);
+            if (userArg == null)
+                throw GenerateException(HttpStatusCode.BadRequest);
+
+            // parse user arg, extract key
+            var partitionKey = userArg.PartitionKey;
+            var rowKey = userArg.RowKey;
+
+            // First, retrieve the metadata
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+
+            // encapsulate to STable entity
+            var arg = Encapsulate(userArg);
+
+            // two cases to check: either the row does not exist, or the row exists with a deleted bit
+            // always try to insert first
+            bool succeed = false;
+            try
+            {
+                InsertRowCOW(arg, meta, options, context);
+                succeed = true;
+            }
+            catch (StorageException e)
+            {
+                if (e.RequestInformation.HttpStatusCode != (int)HttpStatusCode.Conflict)
+                    // give up
+                    throw e;
+            }
+
+            if (!succeed)
+            {
+                // row exists, retrieve
+                var retrieveRes = StorageLayer.RetrieveRow(headTable, TableOperation.Retrieve<STableEntity>(partitionKey, rowKey));
+                if (retrieveRes == null || retrieveRes.HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes.Result == null)
+                    // something weird happened
+                    throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+                // row physically exist, check delete bit
+                var originalRow = (STableEntity)retrieveRes.Result;
+                if (!originalRow.Deleted)
+                    throw GenerateException(HttpStatusCode.Conflict);
+
+                // now we can simply replace the current row w/ COW feature, throw any exception
+                // ignore returned petag
+                
+                ModifyRowCOW(originalRow, TableOperationType.Replace, arg, meta, options, context);
+            }
+
+            // succeed
+            var ret = new TableResult();
+            ret.Result = userArg;
+            userArg.ETag = arg.VETag;    // also set new vetag to userArg
+            userArg.Timestamp = arg.Timestamp;  // insert sets timestamp to userArg
+
+            ret.HttpStatusCode = (int)HttpStatusCode.Created;
+            ret.Etag = userArg.ETag;
+
+            return ret;
+        }
+
+        private TableResult HandleModify(TableOperation operation, TableRequestOptions options, OperationContext context)
+        {
+            // get parameters
+            var opType = GetOpType(operation);
+            var opBackup = opType;
+            Assert.IsTrue(opType == TableOperationType.Replace || opType == TableOperationType.Merge || opType == TableOperationType.Delete);
+            var userArg = GetEntityFromOperation(operation);
+            if (userArg == null)
+                throw GenerateException(HttpStatusCode.BadRequest);
+
+            // parse user arg, extract key & precondition
+            var partitionKey = userArg.PartitionKey;
+            var rowKey = userArg.RowKey;
+            var precond = userArg.ETag;
+
+            // First, retrieve the row and the metadata
+            var headTable = ts.GetHead();
+            var retrieveOps = new List<InternalOperation>();
+            retrieveOps.Add(new InternalOperation(headTable, STableMetadataEntity.RetrieveMetaOp()));
+            retrieveOps.Add(new InternalOperation(headTable, TableOperation.Retrieve<STableEntity>(partitionKey, rowKey)));
+            var retrieveRes = StorageLayer.ConcurrentRetrieve(retrieveOps);
+
+            // check retrieved results
+            if (retrieveRes == null || retrieveRes[0] == null || retrieveRes[1] == null 
+                || retrieveRes[0].HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes[0].Result == null)
+                // throw ServiceUnavaialbe if we fail to access metadata
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            if (retrieveRes[1].HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes[1].Result == null)
+                // if we get notfound, throw notfound. this is the correct behavior.
+                // otherwise, throw whatever we get.
+                throw GenerateException((HttpStatusCode)retrieveRes[1].HttpStatusCode);
+
+
+            // row physically exist
+            var meta = (STableMetadataEntity)retrieveRes[0].Result;
+            var originalRow = (STableEntity)retrieveRes[1].Result;
+
+            // check delete bit and vetag
+            if (originalRow.Deleted)
+                throw GenerateException(HttpStatusCode.NotFound);
+
+            if (!VETagMatch(precond, originalRow.VETag))
+                throw GenerateException(HttpStatusCode.PreconditionFailed);
+
+            // encapsulate user's arg to STable's arg
+            var arg = Encapsulate(userArg);
+
+            // change delete to a special replace
+            if (opType == TableOperationType.Delete)
+            {
+                opType = TableOperationType.Replace;
+                arg.Deleted = true;
+            }
+
+            // modify the row, throw any exception, ignore returned physical etag
+            ModifyRowCOW(originalRow, opType, arg, meta, options, context);
+
+            var ret = new TableResult();
+            ret.Result = userArg;
+            if (opBackup != TableOperationType.Delete)
+            {
+                // replace & merge set new vetag to userArg, delete does not set it.
+                userArg.ETag = arg.VETag;
+            }
+            // replace, merge and delete do not change timestamp of the returned entity
+
+            ret.HttpStatusCode = (int)HttpStatusCode.NoContent;
+            ret.Etag = userArg.ETag;
+
+            return ret;       
+        }
+
+        private TableResult HandleIOX(TableOperation operation, TableRequestOptions options, OperationContext context)
+        {
+            // get parameters
+            var opType = GetOpType(operation);
+            var userArg = GetEntityFromOperation(operation);
+            if (userArg == null)
+                throw GenerateException(HttpStatusCode.BadRequest);
+
+            // parse user arg, extract key & precondition
+            var partitionKey = userArg.PartitionKey;
+            var rowKey = userArg.RowKey;
+
+            // First, retrieve the row and the metadata
+            var headTable = ts.GetHead();
+            var retrieveOps = new List<InternalOperation>();
+            retrieveOps.Add(new InternalOperation(headTable, STableMetadataEntity.RetrieveMetaOp()));
+            retrieveOps.Add(new InternalOperation(headTable, TableOperation.Retrieve<STableEntity>(partitionKey, rowKey)));
+            var retrieveRes = StorageLayer.ConcurrentRetrieve(retrieveOps);
+
+            // check retrieved results
+            if (retrieveRes == null || retrieveRes[0] == null || retrieveRes[1] == null 
+                || retrieveRes[0].HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes[0].Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            var meta = (STableMetadataEntity)retrieveRes[0].Result;
+            
+            // encapsulate user's arg to STable's arg
+            var arg = Encapsulate(userArg);
+
+            if (retrieveRes[1].HttpStatusCode == (int)HttpStatusCode.NotFound)
+            {
+                // row does not exist, just insert a row, throw any exception
+                InsertRowCOW(arg, meta, options, context);
+            }
+            else if (retrieveRes[1].HttpStatusCode == (int)HttpStatusCode.OK && retrieveRes[1].Result != null)
+            {
+                // row exists
+                var originalRow = (STableEntity)retrieveRes[1].Result;
+
+                if (!originalRow.Deleted)
+                {
+                    // if the row is logically there, issue replace / merge
+                    if (opType == TableOperationType.InsertOrReplace)
+                        opType = TableOperationType.Replace;
+                    else
+                        opType = TableOperationType.Merge;
+                }
+                else
+                {
+                    // if the row is logically deleted, always issue replace
+                    opType = TableOperationType.Replace;
+                }
+
+                ModifyRowCOW(originalRow, opType, arg, meta, options, context);
+            }
+            else
+                // unknown cases
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            // succeed
+            var ret = new TableResult();
+            ret.Result = userArg;
+            userArg.ETag = arg.VETag;    // IOX sets new vetag to userArg
+            // iox does not change timestamp of userArg
+            
+            ret.HttpStatusCode = (int)HttpStatusCode.NoContent;
+            ret.Etag = arg.VETag;
+
+            return ret;      
+        }
+
+        private TableResult HandleRetrieveFromSnapshot(TableOperation operation, int ssid, TableRequestOptions options, OperationContext context)
+        {
+            // get parameters
+            var partitionKey = GetPartitionKeyFromOperation(operation);
+            var rowKey = GetRowKeyFromOperation(operation);
+
+            // First, retrieve the row and the metadata
+            var headTable = ts.GetHead();
+            var retrieveOps = new List<InternalOperation>();
+            retrieveOps.Add(new InternalOperation(headTable, STableMetadataEntity.RetrieveMetaOp()));
+            retrieveOps.Add(new InternalOperation(headTable, TableOperation.Retrieve<STableEntity>(partitionKey, rowKey)));
+            var retrieveRes = StorageLayer.ConcurrentRetrieve(retrieveOps);
+
+            // check retrieved results
+            if (retrieveRes == null || retrieveRes[0] == null || retrieveRes[1] == null
+                || retrieveRes[0].HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes[0].Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            var meta = (STableMetadataEntity)retrieveRes[0].Result;
+            
+            if (!meta.IsSnapshotValid(ssid))
+                // not alowed, we can only read into history
+                throw GenerateException(HttpStatusCode.BadRequest);
+
+            // res should return the TableResult of accessing the snapshot (i.e., not decapsulated, contain the STableEntity)
+            // needOpt should be set to true if the snapshot is not retrieved from ST_{ssid}.
+            TableResult res = null;
+            bool needOpt = false;
+
+            // handle result
+            if (retrieveRes[1].HttpStatusCode == (int)HttpStatusCode.NotFound)
+            {
+                // row has never been inserted throughout the history
+                // in this case, we need to insert a dummy row to solidify this snapshot
+                // see comment below
+
+                // no vetag & payload
+                var dummyInsertArg = new STableEntity(partitionKey, rowKey);
+                dummyInsertArg.SSID = meta.CurrentSSID;
+                dummyInsertArg.Deleted = true;
+
+                // throw any exception
+                InsertRowCOW(dummyInsertArg, meta, null, null);
+
+                // succeed, return the "deleted" dummy row for optimiation, same as returning a "NotFound"
+                res = new TableResult();
+                res.HttpStatusCode = (int)HttpStatusCode.OK;
+                res.Result = dummyInsertArg;
+                res.Etag = null;
+                needOpt = true;
+            }
+            else if (retrieveRes[1].HttpStatusCode == (int)HttpStatusCode.OK && retrieveRes[1].Result != null)
+            {
+                var headData = (STableEntity)retrieveRes[1].Result;
+
+                if (headData.SSID > ssid)
+                {
+                    // in this case, row's snapshot 0 - snapshot headData.SSID - 1 (incl. ssid) have been solidified
+                    // directly go to the corresponding table, throw any exception
+                    int steps = 0;
+                    res = ReadSnapshotChain(partitionKey, rowKey, ssid, meta, out steps, options, context);
+                    needOpt = (steps > 1);
+                }
+                else
+                {
+                    // headData.SSID <= ssid < CurrentSSID
+                    // In this case, we should return the row in place.
+                    // However, the snapshot ssid is not yet valid, and we are vulnerable to concurrent modification (esp. slow update)
+                    // We want to solidify the row to CurrentSSID - 1 (will make snapshot ssid valid, and equal to current row) before returning.
+                    // See invariant 4 in ModifyRowCOW & comment on SSID in STableEntity.
+
+                    // We issue a "dummy" update on this row in SSID CurrentSSID.
+                    // This will COW the current row to snapshot table headData.SSID, and increament this row's current SSID to CurrentSSID.
+                    // Once this "dummy" update succeeds, no one can change this row from SSID headData.SSID to CurrentSSID - 1, including ssid.
+
+                    // This technique prevents concurrent updates to change the row's content on snapshot ssid, and causes non-repeatable read.
+                    // E.g., Assume initially the row's head SSID is ssid, and an update reads CurrentSSID = ssid, then sleeps a long time
+                    // before updating the row. Someone takes snapshot ssid, and we come to read this row in snapshot ssid before the update awakes.
+                    // If we do not issue the dummy update, later the update can wake up and successfully update the row in ssid.
+                    // In this case, if we read this row in history ssid again, we will get a different result.
+
+                    var dummyMergeArg = new STableEntity(partitionKey, rowKey);
+                    dummyMergeArg.Deleted = headData.Deleted;
+                    dummyMergeArg.VETag = headData.VETag;
+                    dummyMergeArg.Payload.Clear();
+
+                    // throw any exception, ignore returned physical ETag
+                    ModifyRowCOW(headData, TableOperationType.Merge, dummyMergeArg, meta, null, null);
+
+                    // now, the snapshots have been solidified
+                    res = retrieveRes[1];
+                    needOpt = (headData.SSID < ssid);
+                }
+            }
+            else
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            Assert.IsTrue(res != null && (res.HttpStatusCode == (int)HttpStatusCode.NotFound
+                || (res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null && res.Result is STableEntity)));
+
+            if (needOpt)
+                // optimization, copy snapshot in place to accelerate future requests
+                CopySnapshot(partitionKey, rowKey, res, ssid);
+
+            // decapsulate
+            if (res.HttpStatusCode == (int)HttpStatusCode.OK)
+            {
+                var rawData = (STableEntity)res.Result;
+                if (rawData.Deleted)
+                {
+                    res.HttpStatusCode = (int)HttpStatusCode.NotFound;
+                    res.Result = null;
+                    res.Etag = null;
+                }
+                else
+                {
+                    res.HttpStatusCode = (int)HttpStatusCode.OK;
+                    res.Result = Decapsulate(rawData, operation);
+                    res.Etag = rawData.VETag;
+                }
+            }
+
+            return res;   
+        }
+
+
+        // Methods to modify a row in head table while corrspondingly updating the chained
+        // snapshot tables.
+        // All operations to the head table should go through these methods.
+
+        // Insert a row into the head table as the initial version. No COW is needed.
+        // The row shold have correct delete bit, vetag and payload, The ssid and the version
+        // are managed by this method.
+        // SSID will be set to meta.CurrentSSID.
+        // Version will be set to 1.
+        // 
+        // Requirement:
+        //    1. The row must not exist.
+        // Return:
+        //    1. On success, return the physical eTag of the inserted row in head table.
+        //       The ssid and the version are assigned to the row. Timestamp is updated.
+        //    2. Otherwise, throw a storage exception with http error code.
+        private string InsertRowCOW(STableEntity row, STableMetadataEntity meta, 
+            TableRequestOptions options, OperationContext context)
+        {
+            row.SSID = meta.CurrentSSID;
+            row.Version = STableEntity.InitialVersion;
+
+            var headTable = ts.GetHead();
+            var flushRes = StorageLayer.ModifyRow(headTable, TableOperationType.Insert, row, null, options, context);
+            if (flushRes == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            else if (flushRes.HttpStatusCode != (int)HttpStatusCode.Created)
+                // failed
+                // if the row exist, we get conflict, and also throw conflict
+                throw GenerateException((HttpStatusCode)flushRes.HttpStatusCode);
+
+            return flushRes.Etag;
+        }
+
+        // Input an existing row in head table. Execute opType (can only be Replace /
+        // Merge) with arg on it. COW if necessary.
+        // The argument should have correct delete bit, vetag and payload. The SSID and
+        // the version are managed by this method.
+        // SSID will be updated to max(meta.CurrentSSID, originalRow.SSID).
+        // Version will be originalRow.Version + 1.
+        //
+        // Requirement:
+        //    1. the row exists, and is latest (we will condition on its current petag).
+        //    2. opType is replace or merge.
+        //    3. the operation is on the original row, i.e., arg.key == originalRow.key.
+        // Return:
+        //    1. On success, return the physical eTag of the modified row in head table.
+        //       The ssid and the version number are also assigned to the arg. Timestamp
+        //       is updated.
+        //    2. On fail, throw a http error code.
+        // Invariants:
+        //    1. Update to a row in head table via this API is linearlizable.
+        //    2. The ssid of a row in head table never decrease, i.e., we only modify the
+        //       row to the same or later ssid (= meta.CurrentSSID).
+        //    3. The version of a row in head table always increase for every successful
+        //       call. Every <s, v> maps to a unique entity.
+        //    4. Once a ModifyRowCOW takes a row in head table from snapshot s to s',
+        //       snapshots of the row in s, s+1, ..., s'-1 are solidified forever in the
+        //       version that this operation sees (i.e., parameter originalRow).
+        private string ModifyRowCOW(STableEntity originalRow, TableOperationType opType, STableEntity arg,
+            STableMetadataEntity meta, TableRequestOptions options, OperationContext context)
+        {
+            Assert.IsTrue(originalRow != null);
+            Assert.IsTrue(opType == TableOperationType.Replace || opType == TableOperationType.Merge);
+            Assert.IsTrue(arg != null);
+            Assert.IsTrue(arg.PartitionKey == originalRow.PartitionKey && arg.RowKey == originalRow.RowKey);
+
+            // extract parameters
+            var originalPETag = originalRow.ETag;
+            var partitionKey = originalRow.PartitionKey;
+            var rowKey = originalRow.RowKey;
+
+            // Assign new ssid of the row after this modification.
+            // In most cases, new ssid = meta.CurrentSSID.
+            // But if currentSSID <= originalRow.SSID, we are too slow, others has made huge progress.
+            // We are concurrent with the snapshot op & the op that updates the row after snapshot.
+            // In this case, we simply set new SSID = originalRow.SSID.
+            // This ensures a row's ssid never decrease.
+            arg.SSID = Math.Max(meta.CurrentSSID, originalRow.SSID);
+
+            // Assign new version of the row
+            arg.Version = originalRow.Version + 1;
+
+            var headTable = ts.GetHead();
+            if (arg.SSID == originalRow.SSID)
+            {
+                // no need to COW, use a simple atomic write
+                var flushRes = StorageLayer.ModifyRow(headTable, opType, arg, originalPETag, options, context);
+                if (flushRes == null || flushRes.HttpStatusCode != (int)HttpStatusCode.NoContent)
+                    // failed
+                    throw GenerateException(HttpStatusCode.Conflict);
+
+                return flushRes.Etag;
+            }
+            else
+            {
+                // arg.SSID > originalRow.SSID, need COW
+                Assert.IsTrue(arg.SSID > originalRow.SSID);
+                Assert.IsTrue(arg.SSID == meta.CurrentSSID);
+
+                // but what if snapshot originalRow.SSID has been deleted?
+                // we should COW to the next valid snapshot...
+                // note that meta.CurrentSSID == new SSID > originalRow.SSID
+                // so meta has information for snapshot ids 0 .. new SSID - 1, incl. originalRow.SSID.
+                if (!meta.IsSnapshotValid(originalRow.SSID))
+                {
+                    int? nextSnapshot = meta.NextSnapshot(originalRow.SSID);
+                    if (nextSnapshot.HasValue)
+                    {
+                        Assert.IsTrue(arg.SSID > nextSnapshot.Value);
+                        originalRow.SSID = nextSnapshot.Value;
+                    }
+                    else
+                    {
+                        // we are sure there is no valid snapshot from originalRow.SSID to arg.SSID - 1
+                        // as we are just writing arg.SSID, we do not need to COW
+                        originalRow.SSID = arg.SSID;
+                    }
+                }
+
+                if (arg.SSID > originalRow.SSID)
+                {
+                    // really need COW
+                    var cowResponse = CopyOnWrite(originalRow);
+                    if (cowResponse != HttpStatusCode.Created)
+                    {
+                        // failed to cow, abort
+                        throw GenerateException(cowResponse);
+                    }
+                }
+
+                // flush data in place
+                var flushRes = StorageLayer.ModifyRow(headTable, opType, arg, originalPETag, options, context);
+                if (flushRes == null || flushRes.HttpStatusCode != (int)HttpStatusCode.NoContent)
+                {
+                    // failed, abort
+                    // In such cases, we need not to worry about the COW data we just written to snapshot table.
+                    //   - If the head is still in originalRow.SSID, the data we COWed is not yet valid, and will
+                    //     be replaced during future modification of the row.
+                    //   - If the head has progressed to higher SSID, another operation o' must have done a successful
+                    //     ModifyRowCOW, taking the row from SSID to a higher one. So o' must have written the correct
+                    //     data to snapshot table.
+                    //     But can we violate invariant 4 by having overwritten the COWed data from o'? Note that
+                    //     the data COWed by o' must be at least in version <s, v> (otherwise o' will fail). Since
+                    //     COW will not decreament the version of this row on ST_s, so either o' overwrites our
+                    //     COWed data, or we are both writing <s, v>.
+                    throw GenerateException(HttpStatusCode.Conflict);
+                }
+
+                return flushRes.Etag;
+            }
+        }
+
+        // Copy on write the current row to its snapshot table.
+        // We only copy a row that once physically exists in head table (i.e., currentRow is read from head).
+        // The COW will only succeed if ST_{row.s}[row].ver <= currentRow.ver.
+        // If ST_{row.s}[row].ver == currentRow.ver, we will succeed but will not copy again.
+        // On succeed, return Created, otherwise return error code.
+        private HttpStatusCode CopyOnWrite(STableEntity currentRow)
+        {
+            var ssTable = ts.GetSnapshot(currentRow.SSID);
+                    
+            var res = StorageLayer.ModifyRow(ssTable, TableOperationType.Insert, currentRow, null);
+            if (res == null)
+                return HttpStatusCode.ServiceUnavailable;
+            else if (res.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                // table not found, meta block is out of date, abort with conflict
+                // TODO: shall we return conflict for all cases?
+                return HttpStatusCode.Conflict;
+            else if (res.HttpStatusCode == (int)HttpStatusCode.Conflict)
+            {
+                // need to check version
+                var partitionKey = currentRow.PartitionKey;
+                var rowKey = currentRow.RowKey;
+                var retrieveRes = StorageLayer.RetrieveRow(ssTable, TableOperation.Retrieve<STableEntity>(partitionKey, rowKey));
+                if (retrieveRes == null || retrieveRes.HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes.Result == null)
+                    return HttpStatusCode.ServiceUnavailable;
+
+                var oldContent = (STableEntity)retrieveRes.Result;
+                if (oldContent.Version > currentRow.Version)
+                    return HttpStatusCode.Conflict;
+
+                if (oldContent.Version == currentRow.Version)
+                    return HttpStatusCode.Created;
+
+                // oldContent.Version < currentRow.Version, need to copy again
+                var replaceRes = StorageLayer.ModifyRow(ssTable, TableOperationType.Replace, currentRow, oldContent.ETag);
+                if (replaceRes == null)
+                    return HttpStatusCode.ServiceUnavailable;
+                else if (replaceRes.HttpStatusCode == (int)HttpStatusCode.NoContent)
+                    return HttpStatusCode.Created;
+                else
+                    return (HttpStatusCode)replaceRes.HttpStatusCode;
+            }
+            else
+                // on succeed, return created, otherwise return error code
+                return (HttpStatusCode)res.HttpStatusCode;
+        }
+
+
+        // Methods to read snapshot chain & optimizations
+
+        private TableResult ReadSnapshotChain(string pKey, string rKey, int ssid, STableMetadataEntity meta,
+            out int steps, TableRequestOptions options, OperationContext context)
+        {
+            steps = 0;
+            var ssids = meta.GetSSIDEnumerator(ssid);
+
+            while (ssids.hasMoreSSID())
+            {
+                ++steps;
+                int v = ssids.getSSIDAndMovePrev();
+                var retrieveRes = StorageLayer.RetrieveRow(ts.GetSnapshot(v), 
+                    TableOperation.Retrieve<STableEntity>(pKey, rKey), options, context);
+
+                if (retrieveRes == null)
+                    throw GenerateException(HttpStatusCode.ServiceUnavailable);
+                if (retrieveRes.HttpStatusCode == (int)HttpStatusCode.OK && retrieveRes.Result != null)
+                {
+                    // got it
+                    return retrieveRes;
+                }
+                else if (retrieveRes.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                    // check next table
+                    continue;
+                else
+                    throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            }
+
+            // not found
+            var ret = new TableResult();
+            ret.HttpStatusCode = (int)HttpStatusCode.NotFound;
+            ret.Result = null;
+            ret.Etag = null;
+            return ret;
+        }
+
+        // optimization, copy a retrieved snapshot (from chain) into the direct snapshot table
+        private void CopySnapshot(string pKey, string rKey, TableResult res, int ssid)
+        {
+            Assert.IsTrue(res != null && (res.HttpStatusCode == (int)HttpStatusCode.NotFound
+                || (res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null && res.Result is STableEntity)));
+
+            var ssTab = ts.GetSnapshot(ssid);
+
+            STableEntity arg = null;
+            if (res.HttpStatusCode == (int)HttpStatusCode.NotFound)
+            {
+                // in such case, insert a deleted dummy entity
+                arg = new STableEntity(pKey, rKey);
+                arg.SSID = ssid;
+                // version of a dummy entity in an already-solidified snapshot is not important
+                arg.Version = STableEntity.InitialVersion;
+                arg.Deleted = true;
+            }
+            else
+            {
+                // simply copy res.Result to table ssid
+                arg = (STableEntity)res.Result;
+                // don't care if it succeeds or not
+            }
+
+            // don't care if it succeeds or not
+            StorageLayer.ModifyRow(ssTab, TableOperationType.Insert, arg, null);
+        }
+
+
+
+        // batch API
+
+        private IList<TableResult> HandleExecuteBatch(TableBatchOperation batch, TableRequestOptions options, OperationContext context)
+        {
+            if (batch == null)
+                throw new ArgumentException();
+
+            // extract all operation types and arguments
+            var ops = new List<Tuple<TableOperationType, ITableEntity>>();
+            foreach (TableOperation op in batch)
+            {
+                var opType = GetOpType(op);
+                if (opType == TableOperationType.Retrieve)
+                {
+                    // in such case, only a single retrieve can be executed
+                    if (batch.Count != 1)
+                        throw GenerateException(HttpStatusCode.BadRequest);
+
+                    var res = new List<TableResult>();
+                    res.Add(HandleRetrieve(op, options, context));
+                    return res;
+                }
+
+                var arg = GetEntityFromOperation(op);
+                ops.Add(new Tuple<TableOperationType, ITableEntity>(opType, arg));
+            }
+
+            // Retrieve all the rows and the metadata;
+            var headTable = ts.GetHead();
+            var retrieveOps = new List<InternalOperation>();
+            retrieveOps.Add(new InternalOperation(headTable, STableMetadataEntity.RetrieveMetaOp()));
+            foreach (var op in ops)
+            {
+                retrieveOps.Add(new InternalOperation(headTable, TableOperation.Retrieve<STableEntity>(op.Item2.PartitionKey, op.Item2.RowKey)));
+            }
+
+            var retrieveRes = StorageLayer.ConcurrentRetrieve(retrieveOps);
+            if (retrieveRes == null || retrieveRes.Count != (ops.Count + 1))
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            if (retrieveRes[0] == null || retrieveRes[0].HttpStatusCode != (int)HttpStatusCode.OK || retrieveRes[0].Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+            // Decide op ssid, here we must have meta.CurrentSSID >= originalRow.ssid
+            var meta = (STableMetadataEntity)retrieveRes[0].Result;
+            if (!CheckBatchMetaUpToDate(meta, retrieveRes))
+            {
+                // Try a second time
+                var retryMetaRes = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+                if (retryMetaRes == null || retryMetaRes.HttpStatusCode != (int)HttpStatusCode.OK || retryMetaRes.Result == null)
+                    throw GenerateException(HttpStatusCode.ServiceUnavailable);
+
+                meta = (STableMetadataEntity)retryMetaRes.Result;
+
+                if (!CheckBatchMetaUpToDate(meta, retrieveRes))
+                    // give up
+                    throw GenerateException(HttpStatusCode.Conflict);
+            }
+            
+            // Check user-level precondition & generate COW operations & build replies, throw any exception
+            List<Tuple<STableEntity, int>> cowRows = null;
+            List<Tuple<TableOperationType, ITableEntity, string>> writeOps = null;
+            List<TableResult> replies = null;
+            CheckBatchAndGeneratePlan(ops, retrieveRes, meta, out cowRows, out writeOps, out replies);
+
+            // Execute COW, throw any exception
+            ExecuteBatchCOW(cowRows);
+
+            // Execute write operation, throw any exception
+            Assert.IsTrue(writeOps.Count == batch.Count);
+            ExecuteBatchWrite(writeOps, options, context);
+
+            // succeed, update userarg's etag & timestamp
+            for (int i = 0; i < ops.Count; ++i)
+            {
+                Assert.IsTrue(((STableEntity)writeOps[i].Item2).VETag.Equals(replies[i].Etag));
+
+                // Delete should not update etag, although we generated a (useless) vetag for the deleted entity.
+                if (ops[i].Item1 != TableOperationType.Delete)
+                    ops[i].Item2.ETag = replies[i].Etag;
+
+                // only insert update userarg's timestamp
+                // TODO: we may fail to get the correct timestamp when insert is changed to a replace
+                // see comment on HandleInsert()
+                if (ops[i].Item1 == TableOperationType.Insert)
+                    ops[i].Item2.Timestamp = writeOps[i].Item2.Timestamp;
+            }
+
+            // return replies
+            return replies;
+        }
+
+        private bool CheckBatchMetaUpToDate(STableMetadataEntity meta, List<TableResult> retrieveRes)
+        {
+            for (int i = 1; i < retrieveRes.Count; ++i)
+            {
+                if (retrieveRes[i] != null && retrieveRes[i].HttpStatusCode == (int)HttpStatusCode.OK && retrieveRes[i].Result != null)
+                {
+                    if (meta.CurrentSSID < ((STableEntity)retrieveRes[i].Result).SSID)
+                        return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Check if all the ops in a batch matches their precondition, generate a plan for execute the batch, including:
+        //   (1) a list of rows that needs to be copy-on-write (including the opindex of each row for error report)
+        //   (2) a list of flushing operations (size == size of batch)
+        //   (3) a list of expected replies to the user (size == size of batch)
+        private void CheckBatchAndGeneratePlan(List<Tuple<TableOperationType, ITableEntity>> ops, List<TableResult> currentRows, STableMetadataEntity meta,
+            out List<Tuple<STableEntity, int>> cowRows, out List<Tuple<TableOperationType, ITableEntity, string>> writeOps, out List<TableResult> replies)
+        {
+            cowRows = new List<Tuple<STableEntity, int>>();     // Item2 is used to store index, for error report
+            writeOps = new List<Tuple<TableOperationType, ITableEntity, string>>();
+            replies = new List<TableResult>();
+
+            for (int i = 0; i < ops.Count; ++i)
+            {
+                var op = ops[i];
+                var rowRes = currentRows[i + 1];
+
+                if (rowRes == null)
+                    throw GenerateBatchException(HttpStatusCode.ServiceUnavailable, i);
+
+                string newVETag = null;
+
+                if (op.Item1 == TableOperationType.Insert)
+                {
+                    if (rowRes.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                    {
+                        STableEntity arg = Encapsulate(op.Item2);
+                        arg.SSID = meta.CurrentSSID;
+                        arg.Version = STableEntity.InitialVersion;
+                        // we cannot immediately overwrite op.Item2, since the batch may fail, in which case we should not change userArg
+                        newVETag = arg.VETag;
+                        writeOps.Add(new Tuple<TableOperationType, ITableEntity, string>(TableOperationType.Insert, arg, null));
+                    }
+                    else if (rowRes.HttpStatusCode == (int)HttpStatusCode.OK && rowRes.Result != null)
+                    {
+                        var row = (STableEntity)rowRes.Result;
+
+                        if (!row.Deleted)
+                            throw GenerateBatchException(HttpStatusCode.Conflict, i);
+
+                        int? cowTarget = FindBatchCOWTargetSSID(row, meta);
+                        if (cowTarget.HasValue)
+                        {
+                            // set row.ssid to indicate where to cow
+                            row.SSID = cowTarget.Value;
+                            cowRows.Add(new Tuple<STableEntity, int>(row, i));
+                        }
+
+                        STableEntity arg = Encapsulate(op.Item2);
+                        arg.SSID = meta.CurrentSSID;
+                        arg.Version = row.Version + 1;
+                        newVETag = arg.VETag;
+                        writeOps.Add(new Tuple<TableOperationType, ITableEntity, string>(TableOperationType.Replace, arg, row.ETag));
+                    }
+                    else
+                        throw GenerateBatchException((HttpStatusCode)rowRes.HttpStatusCode, i);
+
+                    replies.Add(new TableResult() { Result = op.Item2, HttpStatusCode = (int)HttpStatusCode.Created, Etag = newVETag });
+                }
+                else if (op.Item1 == TableOperationType.Replace || op.Item1 == TableOperationType.Merge || op.Item1 == TableOperationType.Delete)
+                {
+                    if (rowRes.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                        throw GenerateBatchException(HttpStatusCode.NotFound, i);
+                    else if (rowRes.HttpStatusCode == (int)HttpStatusCode.OK && rowRes.Result != null)
+                    {
+                        var row = (STableEntity)rowRes.Result;
+
+                        if (row.Deleted)
+                            throw GenerateBatchException(HttpStatusCode.NotFound, i);
+
+                        if (!VETagMatch(op.Item2.ETag, row.VETag))
+                            throw GenerateBatchException(HttpStatusCode.PreconditionFailed, i);
+
+                        int? cowTarget = FindBatchCOWTargetSSID(row, meta);
+                        if (cowTarget.HasValue)
+                        {
+                            // set row.ssid to indicate where to cow
+                            row.SSID = cowTarget.Value;
+                            cowRows.Add(new Tuple<STableEntity, int>(row, i));
+                        }
+
+                        STableEntity arg = Encapsulate(op.Item2);
+                        arg.SSID = meta.CurrentSSID;
+                        arg.Version = row.Version + 1;
+                        newVETag = arg.VETag;
+
+                        // Change delete to replace
+                        TableOperationType targetOpType = op.Item1;
+                        if (op.Item1 == TableOperationType.Delete)
+                        {
+                            targetOpType = TableOperationType.Replace;
+                            arg.Deleted = true;
+                        }
+
+                        writeOps.Add(new Tuple<TableOperationType, ITableEntity, string>(targetOpType, arg, row.ETag));
+                    }
+                    else
+                        throw GenerateBatchException((HttpStatusCode)rowRes.HttpStatusCode, i);
+
+                    replies.Add(new TableResult() { Result = op.Item2, HttpStatusCode = (int)HttpStatusCode.NoContent, Etag = newVETag });
+                }
+                else if (op.Item1 == TableOperationType.InsertOrReplace || op.Item1 == TableOperationType.InsertOrMerge)
+                {
+                    if (rowRes.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                    {
+                        STableEntity arg = Encapsulate(op.Item2);
+                        arg.SSID = meta.CurrentSSID;
+                        arg.Version = STableEntity.InitialVersion;
+                        newVETag = arg.VETag;
+                        writeOps.Add(new Tuple<TableOperationType, ITableEntity, string>(TableOperationType.Insert, arg, null));
+                    }
+                    else if (rowRes.HttpStatusCode == (int)HttpStatusCode.OK && rowRes.Result != null)
+                    {
+                        var row = (STableEntity)rowRes.Result;
+
+                        int? cowTarget = FindBatchCOWTargetSSID(row, meta);
+                        if (cowTarget.HasValue)
+                        {
+                            // set row.ssid to indicate where to cow
+                            row.SSID = cowTarget.Value;
+                            cowRows.Add(new Tuple<STableEntity, int>(row, i));
+                        }
+
+                        STableEntity arg = Encapsulate(op.Item2);
+                        arg.SSID = meta.CurrentSSID;
+                        arg.Version = row.Version + 1;
+                        newVETag = arg.VETag;
+
+                        if (row.Deleted)
+                        {
+                            // always replace in such case
+                            writeOps.Add(new Tuple<TableOperationType, ITableEntity, string>(TableOperationType.Replace, arg, row.ETag));
+                        }
+                        else
+                        {
+                            // issue replace / merge
+                            var targetOpType = (op.Item1 == TableOperationType.InsertOrReplace) ? TableOperationType.Replace : TableOperationType.Merge;
+                            writeOps.Add(new Tuple<TableOperationType, ITableEntity, string>(targetOpType, arg, row.ETag));
+                        }
+                    }
+                    else
+                        throw GenerateBatchException((HttpStatusCode)rowRes.HttpStatusCode, i);
+
+                    replies.Add(new TableResult() { Result = op.Item2, HttpStatusCode = (int)HttpStatusCode.NoContent, Etag = newVETag });
+                }
+                else
+                    // impossible
+                    Assert.IsTrue(false);
+            }
+        }
+
+        // Return if we need to COW a row in batch operation.
+        private int? FindBatchCOWTargetSSID(STableEntity row, STableMetadataEntity meta)
+        {
+            Assert.IsTrue(row.SSID <= meta.CurrentSSID);
+
+            int cowTarget = row.SSID;
+            if (cowTarget == meta.CurrentSSID)
+                // no need for COW
+                return null;
+
+            // logically need to COW to snapshot row.SSID, check if it still exists...
+            if (meta.IsSnapshotValid(cowTarget))
+                return cowTarget;
+            else
+            {
+                int? nextSnapshot = meta.NextSnapshot(cowTarget);
+                if (nextSnapshot.HasValue)
+                {
+                    Assert.IsTrue(nextSnapshot.Value < meta.CurrentSSID);
+                    return nextSnapshot.Value;
+                }
+                else
+                {
+                    // we are sure there is no valid snapshot from row.SSID to currentSSID - 1
+                    // as we are just writing currentSSID, we do not need to COW
+                    return null;
+                }
+            }
+        }
+
+        private void ExecuteBatchCOW(List<Tuple<STableEntity, int>> cowRows)
+        {
+            var cowBySSIDs =
+                from row in cowRows
+                group row by row.Item1.SSID into g
+                select new Tuple<int, List<Tuple<STableEntity, int>>>(g.Key,
+                    g.Aggregate(new List<Tuple<STableEntity, int>>(), (b, row) => {b.Add(row); return b;}));
+
+            foreach (var eachSSID in cowBySSIDs)
+            {
+                var tab = eachSSID.Item1;
+                var rows = eachSSID.Item2;
+                if (rows.Count == 1)
+                {
+                    // batch with single op, issue directly
+                    var response = CopyOnWrite(rows[0].Item1);
+                    if (response != HttpStatusCode.Created)
+                        // failed
+                        throw GenerateBatchException(response, rows[0].Item2);
+                }
+                else
+                {
+                    // first try to issue a batch
+                    var batch = new List<Tuple<TableOperationType, ITableEntity, string>>();
+                    foreach (var row in rows)
+                        batch.Add(new Tuple<TableOperationType, ITableEntity, string>(TableOperationType.Insert, row.Item1, null));
+
+
+                    IList<TableResult> batchRes = null;
+                    var errorIndex = StorageLayer.BatchWrite(ts.GetSnapshot(tab), batch, out batchRes);
+                    
+                    if (errorIndex < 0)
+                    {
+                        // check each result
+                        Assert.IsTrue(batchRes != null && batchRes.Count == rows.Count);
+                        foreach (var res in batchRes)
+                        {
+                            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.Created);
+                        }
+                    }
+                    else
+                    {
+                        // if we encounter any exception, do the cow one by one
+                        foreach (var row in rows)
+                        {
+                            var response = CopyOnWrite(row.Item1);
+
+                            if (response != HttpStatusCode.Created)
+                                // failed
+                                throw GenerateBatchException(response, row.Item2);
+                        }
+                    }
+                }
+            }
+        }
+
+        private void ExecuteBatchWrite(List<Tuple<TableOperationType, ITableEntity, string>> ops, TableRequestOptions options, OperationContext context)
+        {
+            IList<TableResult> results = null;
+
+            var errorIndex = StorageLayer.BatchWrite(ts.GetHead(), ops, out results, options, context);
+            if (errorIndex < 0)
+            {
+                Assert.IsTrue(results != null && results.Count == ops.Count);
+                for (int i = 0; i < ops.Count; ++i)
+                {
+                    if (ops[i].Item1 == TableOperationType.Insert)
+                        Assert.IsTrue(results[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                    else if (ops[i].Item1 == TableOperationType.Replace || ops[i].Item1 == TableOperationType.Merge)
+                        Assert.IsTrue(results[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                    else
+                        // impossible
+                        Assert.IsTrue(false);
+                }
+            }
+            else
+            {
+                Assert.IsTrue(results != null && results.Count == 1);
+                throw GenerateBatchException((HttpStatusCode)results[0].HttpStatusCode, errorIndex);
+            }
+        }
+
+
+
+        // Query API
+
+        private IEnumerable<TElement> HandleExecuteQuery<TElement>(TableQuery<TElement> q) where TElement : ITableEntity, new()
+        {
+            TableQuery<STableEntity> encapedQuery = new TableQuery<STableEntity>();
+            encapedQuery.SelectColumns = q.SelectColumns;
+            if (encapedQuery.SelectColumns != null)
+            {
+                // should at least contain STable's metadata
+                encapedQuery.SelectColumns.Add(STableEntity.KeySSID);
+                encapedQuery.SelectColumns.Add(STableEntity.KeyVersion);
+                encapedQuery.SelectColumns.Add(STableEntity.KeyDeleted);
+                encapedQuery.SelectColumns.Add(STableEntity.KeyVETag);
+            }
+
+            encapedQuery.TakeCount = q.TakeCount;
+
+            // set filter, need to combine a filter on delete bit
+            var deleteFilter = TableQuery.GenerateFilterConditionForBool(STableEntity.KeyDeleted, QueryComparisons.Equal, false);
+            if (q.FilterString != null && !q.FilterString.Equals(""))
+            {
+                var combinedFilter = TableQuery.CombineFilters(deleteFilter, TableOperators.And, q.FilterString);
+                encapedQuery.Where(combinedFilter);
+            }
+            else
+                encapedQuery.Where(deleteFilter);
+
+            var headTable = ts.GetHead();
+            var rawres = headTable.ExecuteQuery(encapedQuery);
+
+            // use a generated retrieve operation for decapsulation
+            // keys are useless, Decapsulate() only uses its default resolver
+            var retrieveOp = TableOperation.Retrieve<TElement>("1", "1");
+            var res = from rawEnt in rawres
+                      select (TElement)Decapsulate(rawEnt, retrieveOp);
+
+            return res;
+        }
+
+
+
+        // Snapshot management
+
+        private STableHistoryInfo HandleGetSTableHistory()
+        {
+            // First, retrieve the meta data
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+            var res = new STableHistoryInfo();
+            res.HeadSSID = meta.CurrentSSID;
+            for (int i = 0; i <= res.HeadSSID; ++i)
+            {
+                var state = SnapshotState.Deleted;
+                if (i == res.HeadSSID)
+                    state = SnapshotState.Head;
+                else if (meta.IsSnapshotValid(i))
+                    state = SnapshotState.Valid;
+
+                res.Snapshots.Add(new SnapshotInfo(i, state, meta.GetParent(i)));
+            }
+
+            return res;
+        }
+
+        // Create a new snapshot, return the new metadata block after creating the snapshot
+        // argument: parentOfNewHead, the parent ssid of the new (unsealed) head version
+        // -1: the parent of the new head is the current version (i.e., parentOfNewHead == CurrentSSID)
+        // CurrentSSID > parentOfNewHead >= 0: the ssid of the parent of the new head version
+        private STableMetadataEntity HandleCreateSnapshot(int parentOfNewHead)
+        {
+            // First, retrieve the meta data
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+            // Create snapshot table for CurrentSSID
+            ts.GetSnapshot(meta.CurrentSSID).CreateIfNotExists();
+
+            // translate parent of new head
+            Assert.IsTrue(parentOfNewHead == -1 || parentOfNewHead >= 0);
+            Assert.IsTrue(parentOfNewHead < meta.CurrentSSID);
+            if (parentOfNewHead == -1)
+                parentOfNewHead = meta.CurrentSSID;
+
+            // Create snapshot in meta block
+            meta.CreateSnapshot(parentOfNewHead);
+
+            var updateRes = StorageLayer.ModifyRow(headTable, TableOperationType.Replace, meta, meta.ETag);
+            if (updateRes == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            else if (updateRes.HttpStatusCode == (int)HttpStatusCode.Conflict || updateRes.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed)
+                throw GenerateException(HttpStatusCode.Conflict);
+            else if (updateRes.HttpStatusCode != (int)HttpStatusCode.NoContent)
+                throw GenerateException((HttpStatusCode)updateRes.HttpStatusCode);
+
+            return meta;
+        }
+
+        private IList<int> HandleListValidSnapshots()
+        {
+            // First, retrieve the meta data
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+            var e = meta.GetSSIDEnumerator();
+            List<int> res = new List<int>();
+
+            while (e.hasMoreSSID())
+                res.Add(e.getSSIDAndMovePrev());
+
+            return res;
+        }
+
+        // Assume no concurrent operations
+        private int HandleRollback(int ssid)
+        {
+            // get metadata
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+            if (!meta.IsSnapshotValid(ssid))
+                // cannnot rollback to a non-existing snapshot
+                throw GenerateException(HttpStatusCode.BadRequest);
+
+            // Create a new snapshot
+            meta = HandleCreateSnapshot(ssid);
+            var saveSSID = meta.CurrentSSID - 1;
+
+            var query = new TableQuery<STableEntity>().Where(TableQuery.GenerateFilterConditionForInt(STableEntity.KeySSID, QueryComparisons.GreaterThan, ssid));
+            var res = headTable.ExecuteQuery<STableEntity>(query);
+            foreach (var row in res)
+            {
+                int steps = 0;
+                var oldVal = ReadSnapshotChain(row.PartitionKey, row.RowKey, ssid, meta, out steps, null, null);
+                Assert.IsTrue(oldVal != null && (oldVal.HttpStatusCode == (int)HttpStatusCode.NotFound || oldVal.HttpStatusCode == (int)HttpStatusCode.OK));
+                STableEntity oldData = null;
+                if (oldVal.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    oldData = new STableEntity(row.PartitionKey, row.RowKey);
+                    oldData.Deleted = true;
+                }
+                else
+                {
+                    Assert.IsTrue(oldVal.Result != null);
+                    oldData = (STableEntity)oldVal.Result;
+                    // restore old delete bit, vetag, and payload
+                }
+
+                // copy old data to head table, but with new ssid and version number, throw any exception
+                ModifyRowCOW(row, TableOperationType.Replace, oldData, meta, null, null);
+            }
+
+            return saveSSID;
+        }
+
+        // Assume no concurrent create snapshot / rollback / delete snapshot / readFromSnapshot
+        private void HandleDeleteSnapshot(int ssid)
+        {
+            // get metadata
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+            if (!meta.IsSnapshotValid(ssid))
+                throw GenerateException(HttpStatusCode.BadRequest);
+                
+            IChainTable targetSS = ts.GetSnapshot(ssid);
+            var adoptor = meta.NextSnapshot(ssid);
+            IChainTable adoptorSS = null;
+            if (adoptor.HasValue)
+                adoptorSS = ts.GetSnapshot(adoptor.Value);
+
+            if (adoptorSS != null)
+            {
+                var query = new TableQuery<STableEntity>();
+                var res = targetSS.ExecuteQuery<STableEntity>(query);
+
+                foreach (var row in res)
+                {
+                    row.SSID = adoptor.Value;
+
+                    // simply do an insert, we accept Created / Conflict
+                    // (NOTICE: IN SUCH CASE, WE REQUIRE CONFLICT TO ONLY MEAN "THE ROW EXISTS", WHICH MAY NOT BE THE CASE FOR RTABLE / STABLE)
+                    var adoptRes = StorageLayer.ModifyRow(adoptorSS, TableOperationType.Insert, row, null);
+                    if (adoptRes == null || (adoptRes.HttpStatusCode != (int)HttpStatusCode.Created && adoptRes.HttpStatusCode != (int)HttpStatusCode.Conflict))
+                        throw GenerateException(HttpStatusCode.ServiceUnavailable);
+                }
+            }
+
+
+            // delete ssid in meta block
+            meta.DeleteSnapshot(ssid);
+            var updateMetaRes = StorageLayer.ModifyRow(headTable, TableOperationType.Replace, meta, meta.ETag);
+            if (updateMetaRes == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            else if (updateMetaRes.HttpStatusCode != (int)HttpStatusCode.NoContent)
+                throw GenerateException((HttpStatusCode)updateMetaRes.HttpStatusCode);
+
+            // finally, delete the target table, do not care succeess or not...
+            targetSS.DeleteIfExists();
+        }
+
+
+
+        // Garbage collection of deleted rows
+        private static readonly int GCBatchSize = 20;
+
+        private void HandleGC()
+        {
+            // get metadata
+            var headTable = ts.GetHead();
+            var metaResult = StorageLayer.RetrieveRow(headTable, STableMetadataEntity.RetrieveMetaOp());
+            if (metaResult == null || metaResult.HttpStatusCode != (int)HttpStatusCode.OK || metaResult.Result == null)
+                throw GenerateException(HttpStatusCode.ServiceUnavailable);
+            var meta = (STableMetadataEntity)metaResult.Result;
+
+            var targetCols = new List<string>();
+
+            var query = new TableQuery<DynamicTableEntity>().Where(TableQuery.GenerateFilterConditionForBool(STableEntity.KeyDeleted, QueryComparisons.Equal, true))
+                .Select(targetCols);
+            var res = headTable.ExecuteQuery<DynamicTableEntity>(query);
+            
+            var deletedRows = new List<Tuple<string, string>>();
+            foreach (var row in res)
+                deletedRows.Add(new Tuple<string, string>(row.PartitionKey, row.RowKey));
+            
+            try
+            {
+                GCDeletedRows(deletedRows, meta);
+            }
+            catch (StorageException)
+            {
+                // ignore any exception
+            }
+        }
+
+        private void GCDeletedRows(List<Tuple<string, string>> deletedRows, STableMetadataEntity meta)
+        {
+            List<bool> canDelete = new List<bool>();
+            for (int i = 0; i < deletedRows.Count; ++i)
+                canDelete.Add(true);
+
+            var rowIdAndPETagToDeleteInEachTable = new List<List<Tuple<int, string>>>();
+
+            var table = ts.GetHead();
+            rowIdAndPETagToDeleteInEachTable.Add(new List<Tuple<int, string>>());
+            GCCheckTable(table, deletedRows, canDelete, rowIdAndPETagToDeleteInEachTable[0]);
+
+            int tableId = 0;
+            var ssids = meta.GetSSIDEnumerator();
+            while (ssids.hasMoreSSID())
+            {
+                var ssid = ssids.getSSIDAndMovePrev();
+                table = ts.GetSnapshot(ssid);
+
+                ++tableId;
+                rowIdAndPETagToDeleteInEachTable.Add(new List<Tuple<int, string>>());
+
+                GCCheckTable(table, deletedRows, canDelete, rowIdAndPETagToDeleteInEachTable[tableId]);
+            }
+            ExecuteGC(deletedRows, canDelete, rowIdAndPETagToDeleteInEachTable, meta);
+        }
+
+        private void GCCheckTable(IChainTable table, List<Tuple<string, string>> rows, List<bool> canDelete,
+            List<Tuple<int, string>> rowIdAndPETagToDeleteInThisTable)
+        {
+            List<int> index = new List<int>();
+            for (int i = 0; i < rows.Count; ++i)
+            {
+                if (canDelete[i])
+                    index.Add(i);
+
+                if (index.Count == GCBatchSize)
+                {
+                    GCCheckRows(table, rows, index, canDelete, rowIdAndPETagToDeleteInThisTable);
+                    index.Clear();
+                }
+            }
+
+            if (index.Count > 0)
+                GCCheckRows(table, rows, index, canDelete, rowIdAndPETagToDeleteInThisTable);
+        }
+
+        private void GCCheckRows(IChainTable table, List<Tuple<string, string>> rows, List<int> index, List<bool> canDelete,
+            List<Tuple<int, string>> rowIdAndPETagToDeleteInThisTable)
+        {
+            if (index.Count == 0)
+                return;
+
+            List<InternalOperation> readOps = new List<InternalOperation>();
+            for (int i = 0; i < index.Count; ++i)
+                readOps.Add(new InternalOperation(table, TableOperation.Retrieve<STableEntity>(rows[index[i]].Item1, rows[index[i]].Item2)));
+
+            var res = StorageLayer.ConcurrentRetrieve(readOps);
+            if (res == null)
+            {
+                // read fail, mark these rows as "cannot delete"
+                for (int i = 0; i < index.Count; ++i)
+                    canDelete[index[i]] = false;
+                return;
+            }
+
+            Assert.IsTrue(res.Count == index.Count);
+
+            for (int i = 0; i < index.Count; ++i)
+            {
+                if (res[i] == null)
+                    canDelete[index[i]] = false;
+                else if (res[i].HttpStatusCode == (int)HttpStatusCode.NotFound)
+                {
+                    // keep mark unchanged
+                }
+                else if (res[i].HttpStatusCode == (int)HttpStatusCode.OK && res[i].Result != null)
+                {
+                    var entity = (STableEntity)res[i].Result;
+                    if (!entity.Deleted)
+                        canDelete[index[i]] = false;
+                    else
+                    {
+                        // keep mark unchanged, need to delete this row in this table if this row eventually needs to be GCed
+                        rowIdAndPETagToDeleteInThisTable.Add(new Tuple<int, string>(index[i], res[i].Etag));
+                    }
+                }
+                else
+                {
+                    // for all unknown cases, mark the row as "cannot delete"
+                    canDelete[index[i]] = false;
+                }
+            }
+        }
+
+        private void ExecuteGC(List<Tuple<string, string>> rows, List<bool> canDelete, List<List<Tuple<int, string>>> rowIdAndPETagToDelete,
+            STableMetadataEntity meta)
+        {
+            var table = ts.GetHead();
+            ExecuteGCTable(table, rows, canDelete, rowIdAndPETagToDelete[0]);
+
+            int tableId = 0;
+            var ssids = meta.GetSSIDEnumerator();
+            while (ssids.hasMoreSSID())
+            {
+                var ssid = ssids.getSSIDAndMovePrev();
+                table = ts.GetSnapshot(ssid);
+                ++tableId;
+                ExecuteGCTable(table, rows, canDelete, rowIdAndPETagToDelete[tableId]);
+            }
+        }
+
+        private void ExecuteGCTable(IChainTable table, List<Tuple<string, string>> rows, List<bool> canDelete,
+            List<Tuple<int, string>> rowIdAndPETagToDelete)  // Item1 == row id, Item2 == petag
+        {
+            var partitionedRows = from rowIdAndPETag in rowIdAndPETagToDelete
+                                  where canDelete[rowIdAndPETag.Item1]
+                                  group rowIdAndPETag by rows[rowIdAndPETag.Item1].Item1 into g
+                                  select g.Aggregate(new List<Tuple<string, string, string>>(), (res, idAndPETag) => 
+                                  { res.Add(new Tuple<string, string, string>   // item1 = pkey, item2 = rkey, item3 = petag
+                                      (rows[idAndPETag.Item1].Item1, rows[idAndPETag.Item1].Item2, idAndPETag.Item2)); return res; });
+
+            foreach (var p in partitionedRows)
+            {
+                var ops = new List<Tuple<TableOperationType,ITableEntity,string>>();
+                foreach (var r in p)
+                    ops.Add(new Tuple<TableOperationType,ITableEntity,string>(TableOperationType.Delete, new STableEntity(r.Item1, r.Item2), r.Item3));
+
+                IList<TableResult> res = null;
+                var errorIndex = StorageLayer.BatchWrite(table, ops, out res);
+
+                if (errorIndex >= 0)
+                {
+                    // delete one by one, ignore any future error
+                    foreach (var r in p)
+                    {
+                        StorageLayer.ModifyRow(table, TableOperationType.Delete, new STableEntity(r.Item1, r.Item2), r.Item3);
+                    }
+                }
+            }
+        }
+
+
+
+        // helpers
+        private TableOperationType GetOpType(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields in WindowsAzureStorage dll
+            PropertyInfo opType = operation.GetType().GetProperty("OperationType", System.Reflection.BindingFlags.GetProperty |
+                                                               System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            TableOperationType opTypeValue = (TableOperationType)(opType.GetValue(operation, null));
+
+            return opTypeValue;
+        }
+
+        private ITableEntity GetEntityFromOperation(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("Entity", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return (ITableEntity)(entity.GetValue(operation, null));
+        }
+
+        private string GetPartitionKeyFromOperation(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("RetrievePartitionKey", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return (string)(entity.GetValue(operation, null));
+        }
+
+        private string GetRowKeyFromOperation(TableOperation operation)
+        {
+
+            // WARNING: We use reflection to read an internal field in OperationType.
+            //          We have a dependency on TableOperation fields WindowsAzureStorage dll
+            PropertyInfo entity = operation.GetType().GetProperty("RetrieveRowKey", System.Reflection.BindingFlags.GetProperty |
+                                                                   System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            return (string)(entity.GetValue(operation, null));
+        }
+
+
+        // Generate a operation Id
+        private string GenerateVETag()
+        {
+            var low = random.Next();
+            var high = random.Next();
+            return low.ToString() + "," + high.ToString();
+        }
+
+        // Check if a vetag (can't be *) matches the requested pattern (can be *)
+        private bool VETagMatch(string pattern, string vetag)
+        {
+            return (pattern.Equals("*") || pattern.Equals(vetag));
+        }
+
+
+        // Encapsulate an ITableEntity to STable's entity with given payload, generate a random vetag
+        // Protocol fields (i.e., ssid & version) are left unset by this method
+        private STableEntity Encapsulate(ITableEntity userEntity)
+        {
+            var res = new STableEntity(userEntity.PartitionKey, userEntity.RowKey, userEntity.Timestamp, userEntity.ETag);
+            res.Deleted = false;
+            res.VETag = GenerateVETag();
+            res.Payload = userEntity.WriteEntity(null);
+
+            return res;
+        }
+
+        // Decapsulate a STable entity back to a given ITableEntity
+        // This will also virtaulize the etag
+        private ITableEntity Decapsulate(STableEntity rawData, TableOperation retrieveOp)
+        {
+            var resolverField = retrieveOp.GetType().GetField("retrieveResolver", BindingFlags.Instance | BindingFlags.NonPublic);
+            var resolver = (Func<string, string, DateTimeOffset, IDictionary<string, EntityProperty>, System.String, System.Object>)
+                resolverField.GetValue(retrieveOp);
+
+            var res = (ITableEntity)resolver.Invoke(rawData.PartitionKey, rawData.RowKey, rawData.Timestamp, rawData.Payload, rawData.VETag);
+
+            return res;
+        }
+
+        private StorageException GenerateException(HttpStatusCode cause)
+        {
+            RequestResult res = new RequestResult();
+            res.HttpStatusCode = (int)cause;
+            return new StorageException(res, "STable exception", null);
+        }
+
+        private ChainTableBatchException GenerateBatchException(HttpStatusCode cause, int opId)
+        {
+            var underlyingEx = GenerateException(cause);
+            throw new ChainTableBatchException(opId, underlyingEx);
+        }
+    }
+}

--- a/stable/STableLib/STableEntity.cs
+++ b/stable/STableLib/STableEntity.cs
@@ -1,0 +1,108 @@
+﻿using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    internal sealed class STableEntity : ITableEntity
+    {
+
+        public string PartitionKey { get; set; }
+
+        public string RowKey { get; set; }
+
+        public string ETag { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+
+
+        // Metadata for snapshot table
+
+        // When head row's ssid = x, all the snapshots from 0 to x - 1 has been solidated,
+        // and can be retrieved by go through the snapshot chain.
+        internal int SSID { get; set; }
+
+        // The version of the row, this will be incremented upon any modification to the
+        // row in head table (incl. user-level & internal), i.e., ModifyRowCOW.
+        internal long Version { get; set; }
+
+        internal bool Deleted { get; set; }
+
+        // Virtual ETag exposed to the user, only valid if !Deleted.
+        internal string VETag { get; set; }
+
+        // User's payload, only valid if !Deleted.
+        internal IDictionary<string, EntityProperty> Payload { get; set; }
+
+
+
+        public STableEntity()
+        {
+            PartitionKey = null;
+            RowKey = null;
+            ETag = null;
+            Timestamp = DateTimeOffset.MinValue;
+
+            SSID = 0;
+            Version = 0;
+            Deleted = false;
+            VETag = "";
+            Payload = new Dictionary<string, EntityProperty>();
+        }
+        
+        public STableEntity(string partitionKey, string rowKey)
+            : this(partitionKey, rowKey, DateTimeOffset.MinValue, null)
+        {
+        }
+
+        public STableEntity(string partitionKey, string rowKey, DateTimeOffset timestamp, string etag)
+            : this()
+        {
+            this.PartitionKey = partitionKey;
+            this.RowKey = rowKey;
+            this.Timestamp = timestamp;
+            this.ETag = etag;
+        }
+
+        public void ReadEntity(IDictionary<string, EntityProperty> properties, OperationContext operationContext)
+        {
+            Dictionary<string, EntityProperty> prop = new Dictionary<string, EntityProperty>(properties);
+
+            SSID = (int)prop[KeySSID].Int32Value;
+            prop.Remove(KeySSID);
+
+            Version = (long)prop[KeyVersion].Int64Value;
+            prop.Remove(KeyVersion);
+
+            Deleted = (bool)prop[KeyDeleted].BooleanValue;
+            prop.Remove(KeyDeleted);
+
+            VETag = prop[KeyVETag].StringValue;
+            prop.Remove(KeyVETag);
+
+            Payload = prop;
+        }
+
+
+        public IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
+        {
+            var prop = new Dictionary<string, EntityProperty>(Payload);
+            prop.Add(KeySSID, new EntityProperty(SSID));
+            prop.Add(KeyVersion, new EntityProperty(Version));
+            prop.Add(KeyDeleted, new EntityProperty(Deleted));
+            prop.Add(KeyVETag, new EntityProperty(VETag));
+
+            return prop;
+        }
+
+        internal static readonly int InitialVersion = 1;
+        internal static readonly string KeySSID = "__SSID";
+        internal static readonly string KeyVersion = "__Version";
+        internal static readonly string KeyDeleted = "__Deleted";
+        internal static readonly string KeyVETag = "__VETag";
+    }
+}

--- a/stable/STableLib/STableHistoryInfo.cs
+++ b/stable/STableLib/STableHistoryInfo.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    public class STableHistoryInfo
+    {
+        public int HeadSSID { get; set; }
+
+        public List<SnapshotInfo> Snapshots { get; set; }
+
+        public SnapshotInfo GetSnapshot(int ssid)
+        {
+            if (ssid < 0 || ssid > HeadSSID)
+                throw new ArgumentOutOfRangeException();
+
+            return Snapshots[ssid];
+        }
+
+        public STableHistoryInfo()
+        {
+            Snapshots = new List<SnapshotInfo>();
+        }
+    }
+
+    public enum SnapshotState
+    {
+        Head,       // this is the head version, not a valid snapshot
+        Valid,      // this is a valid and existing snapshot
+        Deleted,    // this snapshot has been deleted
+    }
+
+    public class SnapshotInfo
+    {
+        public static readonly int NoParent = -1;
+
+        public int SSID { get; private set; }
+        public SnapshotState State { get; private set; }
+        public int Parent { get; private set; }
+
+        public SnapshotInfo(int ssid, SnapshotState state, int parent)
+        {
+            this.SSID = ssid;
+            this.State = state;
+            this.Parent = parent;
+        }
+    }
+}

--- a/stable/STableLib/STableLib.csproj
+++ b/stable/STableLib/STableLib.csproj
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5881CD5F-E467-497C-8A5B-46AC8B79A0B8}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>STableLib</RootNamespace>
+    <AssemblyName>STableLib</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Azure.KeyVault.Core, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Azure.KeyVault.Core.1.0.0\lib\net40\Microsoft.Azure.KeyVault.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.6.4\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.6.4\lib\net40\Microsoft.Data.OData.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.Data.Services.Client, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.Data.Services.Client.5.6.4\lib\net40\Microsoft.Data.Services.Client.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.6.1.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Newtonsoft.Json.6.0.8\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Spatial, Version=5.6.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Spatial.5.6.4\lib\net40\System.Spatial.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="STableEntity.cs" />
+    <Compile Include="DefaultSTableConfig.cs" />
+    <Compile Include="STable.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ISTableConfig.cs" />
+    <Compile Include="STableHistoryInfo.cs" />
+    <Compile Include="STableMetadataEntity.cs" />
+    <Compile Include="StorageLayer.cs" />
+    <Compile Include="TableService.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ChainTableInterface\ChainTableInterface.csproj">
+      <Project>{c24bc418-9bfd-48fa-94be-8dc8864c2ea6}</Project>
+      <Name>ChainTableInterface</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="app.config" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/stable/STableLib/STableMetadataEntity.cs
+++ b/stable/STableLib/STableMetadataEntity.cs
@@ -1,0 +1,244 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    class STableMetadataEntity : ITableEntity
+    {
+        // Generate a retrieve op to get meta entity
+        internal static TableOperation RetrieveMetaOp()
+        {
+            return TableOperation.Retrieve<STableMetadataEntity>(MetaPKey, MetaRKey);
+        }
+
+
+
+        public string PartitionKey { get; set; }
+
+        public string RowKey { get; set; }
+
+        public string ETag { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+
+
+        // Metadata block
+
+        // Valid snapshots: 0 .. CurrentSSID - 1
+        // Current (unsealed) snapshot: CurrentSSID
+        internal int CurrentSSID { get; private set; }
+
+        // valid ssid list does not contain the current unsealed snapshot (CurrentSSID)
+        private List<int> ValidSSID { get; set; }
+
+        // SSIDHistory contains the parent information of the current unsealed snapshot (CurrentSSID)
+        // It also contains the parent information for all the deleted snapshots
+        // i.e., it contains information for SSID 0 .. CurrentSSID
+        // SSIDHistory.Count == CurrentSSID + 1;
+        private List<int> SSIDHistory { get; set; }
+
+
+        public STableMetadataEntity()
+        {
+            PartitionKey = MetaPKey;
+            RowKey = MetaRKey;
+            ETag = null;
+            Timestamp = DateTimeOffset.MinValue;
+
+            CurrentSSID = 0;
+            ValidSSID = new List<int>();
+            SSIDHistory = new List<int>();
+            SSIDHistory.Add(SnapshotInfo.NoParent);    // ssid0 is the root, no parent
+        }
+        
+        public STableMetadataEntity(string partitionKey, string rowKey)
+            : this(partitionKey, rowKey, DateTimeOffset.MinValue, null)
+        {
+        }
+
+        public STableMetadataEntity(string partitionKey, string rowKey, DateTimeOffset timestamp, string etag)
+            : this()
+        {
+            this.PartitionKey = partitionKey;
+            this.RowKey = rowKey;
+            this.Timestamp = timestamp;
+            this.ETag = etag;
+        }
+
+        public void ReadEntity(IDictionary<string, EntityProperty> properties, OperationContext operationContext)
+        {
+            CurrentSSID = (int)properties[KeyCurrentSSID].Int32Value;
+
+            ValidSSID.Clear();
+            string vsData = properties[KeyValidSSID].StringValue;
+            Assert.IsTrue(vsData != null);
+            if (!vsData.Equals(""))
+            {
+                string[] vs = vsData.Split(',');
+                for (int i = 0; i < vs.Length; ++i)
+                    ValidSSID.Add(int.Parse(vs[i]));
+            }
+
+            SSIDHistory.Clear();
+            string shData = properties[KeySSIDHist].StringValue;
+            Assert.IsTrue(shData != null && !shData.Equals(""));
+            string[] sh = shData.Split(',');
+            for (int i = 0; i < sh.Length; ++i)
+                SSIDHistory.Add(int.Parse(sh[i]));
+
+            Assert.IsTrue(SSIDHistory.Count == CurrentSSID + 1);
+        }
+
+
+        public IDictionary<string, EntityProperty> WriteEntity(OperationContext operationContext)
+        {
+            var prop = new Dictionary<string, EntityProperty>();
+            prop.Add(KeyCurrentSSID, new EntityProperty((int?)CurrentSSID));
+            
+            StringBuilder sb = new StringBuilder();
+            if (ValidSSID.Count > 0)
+            {
+                sb.Append(ValidSSID[0]);
+                for (int i = 1; i < ValidSSID.Count; ++i)
+                {
+                    sb.Append(",");
+                    sb.Append(ValidSSID[i]);
+                }
+            }
+            prop.Add(KeyValidSSID, new EntityProperty(sb.ToString()));
+
+            sb = new StringBuilder();
+            Assert.IsTrue(SSIDHistory.Count > 0 && SSIDHistory.Count == CurrentSSID + 1);
+            sb.Append(SSIDHistory[0]);
+            for (int i = 1; i < SSIDHistory.Count; ++i)
+            {
+                sb.Append(",");
+                sb.Append(SSIDHistory[i]);
+            }
+            prop.Add(KeySSIDHist, new EntityProperty(sb.ToString()));
+            
+            return prop;
+        }
+
+
+
+        internal bool IsSnapshotValid(int ssid)
+        {
+            return (ValidSSID.BinarySearch(ssid) >= 0);
+        }
+
+        internal void CreateSnapshot(int parentOfNewHead)
+        {
+            Assert.IsTrue(SSIDHistory.Count == CurrentSSID + 1);
+            Assert.IsTrue(parentOfNewHead >= 0 && parentOfNewHead <= CurrentSSID);
+
+            ValidSSID.Add(CurrentSSID);
+            CurrentSSID++;
+
+            SSIDHistory.Add(parentOfNewHead);
+        }
+
+        internal int GetParent(int ssid)
+        {
+            Assert.IsTrue(ssid >= 0 && ssid <= CurrentSSID);
+            return SSIDHistory[ssid];
+        }
+
+        internal void DeleteSnapshot(int ssid)
+        {
+            int index = ValidSSID.BinarySearch(ssid);
+            Assert.IsTrue(index >= 0 && index < ValidSSID.Count);
+            ValidSSID.RemoveAt(index);
+        }
+
+        internal int? PrevSnapshot(int ssid)
+        {
+            int index = ValidSSID.BinarySearch(ssid);
+            if (index < 0)
+                index = (~index) - 1;
+            else
+                index -= 1;
+
+            if (index < 0)
+                return null;
+            else
+                return ValidSSID[index];
+        }
+
+        internal int? NextSnapshot(int ssid)
+        {
+            int index = ValidSSID.BinarySearch(ssid);
+            if (index < 0)
+                index = ~index;
+            else
+                index += 1;
+
+            if (index >= ValidSSID.Count)
+                return null;
+            else
+                return ValidSSID[index];
+        }
+
+        // Get a valid snapshot id enumerator, the first call to prevSSID() returns ssid
+        internal SSIDEnumerator GetSSIDEnumerator(int ssid)
+        {
+            int index = ValidSSID.BinarySearch(ssid);
+            if (index < 0)
+                return null;
+
+            return new SSIDEnumerator(ValidSSID, index);
+        }
+
+        // get a enumerator for all alid ssids
+        internal SSIDEnumerator GetSSIDEnumerator()
+        {
+            return new SSIDEnumerator(ValidSSID, ValidSSID.Count - 1);
+        }
+
+
+
+        internal class SSIDEnumerator
+        {
+            private List<int> ssids;
+            private int nowat;
+
+            internal SSIDEnumerator(List<int> ssids, int initPos)
+            {
+                this.ssids = ssids;
+                this.nowat = initPos;
+            }
+
+            internal bool hasMoreSSID()
+            {
+                return (nowat >= 0);
+            }
+
+            internal int getSSIDAndMovePrev()
+            {
+                Assert.IsTrue(nowat >= 0);
+                int ans = ssids[nowat];
+                nowat--;
+
+                return ans;
+            }
+        }
+
+
+
+        // address of this metadata entity
+        private static readonly string MetaPKey = "__STable_Meta";
+        private static readonly string MetaRKey = "__STable_Meta";
+
+        private static readonly string KeyCurrentSSID = "__CurrentSSID";
+        private static readonly string KeyValidSSID = "__ValidSSID";
+        private static readonly string KeySSIDHist = "__SSIDHistory";
+    }
+
+
+}

--- a/stable/STableLib/StorageLayer.cs
+++ b/stable/STableLib/StorageLayer.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.Auth;
+using Microsoft.WindowsAzure.Storage.Table;
+using Microsoft.WindowsAzure.Storage.Core.Util;
+using System.Net;
+using System.Diagnostics;
+using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+
+    class StorageLayer
+    {
+        // Single-op API: execute a single operation on an underlying table
+        /*
+         * RetrieveRow
+         *   Read a row.
+         * 
+         * param:
+         *   A retrieve operation
+         *   (Currently do not support partitionID + rowID, since Operation has another important information, i.e., deserializer)
+         * 
+         * return:
+         *   query result.
+         */
+
+        internal static TableResult RetrieveRow(IChainTable table, TableOperation operation, TableRequestOptions requestOptions = null,
+            OperationContext operationContext = null)
+        {
+            TableResult retrievedResult = null;
+            try
+            {
+                retrievedResult = table.Execute(operation, requestOptions, operationContext);
+            }
+            catch (StorageException e)
+            {
+                return new TableResult() { Result = null, Etag = e.RequestInformation.Etag, HttpStatusCode = e.RequestInformation.HttpStatusCode };
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Error in Retrieve: caught exception {0}", e);
+                return null;
+            }
+
+            return retrievedResult;
+        }
+
+        internal static TableResult RetrieveRowThrow(IChainTable table, TableOperation operation, TableRequestOptions requestOptions = null,
+            OperationContext operationContext = null)
+        {
+            return table.Execute(operation, requestOptions, operationContext); 
+        }
+
+        /*
+         * ReadModifyWriteRow
+         *   Execute a conditional write operation on a row.
+         *   
+         *   Insert         - Success if currently no row exists on the key.
+         *   Update & Merge - success only if current row exists and etag matches.
+         *   Delete         - Success only if current row exist, and etag matches.
+         * 
+         * param:
+         *   table  - target table.
+         *   opType - operation to execute, Insert / Replace / Merge / Delete.
+         *   row    - target row to insert / delete, also serves as the parameter used for insert / replace / merge.
+         *   etag   - for replace / merge / delete, provide the etag of target row.
+         *   
+         * return:
+         *   The result of query. Return null if the Azure request throws an unknown exception.
+         */
+        internal static TableResult ModifyRow(IChainTable table, TableOperationType opType, ITableEntity row, string eTag,
+            TableRequestOptions requestOptions = null, OperationContext operationContext = null)
+        {
+            Assert.IsTrue(opType == TableOperationType.Insert || eTag != null);
+            
+            if (eTag != null)
+                row.ETag = eTag;
+
+            return WriteConditionalRow(table, opType, row, requestOptions, operationContext);
+        }
+
+        // guarantee to return a list of same size
+        internal static List<TableResult> ConcurrentRetrieve(List<InternalOperation> ops)
+        {
+            var tasks = new List<Task<TableResult>>();
+            foreach (var op in ops)
+            {
+                tasks.Add(op.target.ExecuteAsync(op.op, op.options, op.context));
+            }
+
+            var res = new List<TableResult>();
+            try
+            {
+                foreach (var task in tasks)
+                {
+                    task.Wait();
+                    res.Add(task.Result);
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.ToString());
+                return null;
+            }
+
+            return res;
+        }
+
+        // execute batch write on a same partition of a same underlying table
+        // on succeed, res is filled with exact number of table results, and return -1
+        // otherwise, res only contain a single table result of error, and return the error index
+        internal static int BatchWrite(IChainTable table, List<Tuple<TableOperationType, ITableEntity, string>> ops, out IList<TableResult> res,
+            TableRequestOptions options = null, OperationContext context = null)
+        {
+            TableBatchOperation batch = new TableBatchOperation();
+            foreach (var op in ops)
+            {
+                Assert.IsTrue(op.Item1 == TableOperationType.Insert || op.Item3 != null);
+                if (op.Item3 != null)
+                    op.Item2.ETag = op.Item3;
+                batch.Add(TranslateWriteOp(op.Item1, op.Item2));
+            }
+
+            try
+            {
+                res = table.ExecuteBatch(batch);
+                return -1;
+            }
+            catch (ChainTableBatchException e)
+            {
+                res = new List<TableResult>();
+                res.Add(new TableResult() { Result = null, Etag = e.RequestInformation.Etag, HttpStatusCode = e.RequestInformation.HttpStatusCode });
+                return e.FailedOpIndex;
+            }
+        }
+
+
+
+
+        // Helper functions for single-op API
+        private static TableOperation TranslateWriteOp(TableOperationType opType, ITableEntity row)
+        {
+            TableOperation top = null;
+            if (opType == TableOperationType.Delete)
+                top = TableOperation.Delete(row);
+            else if (opType == TableOperationType.Merge)
+                top = TableOperation.Merge(row);
+            else if (opType == TableOperationType.Replace)
+                top = TableOperation.Replace(row);
+            else if (opType == TableOperationType.Insert)
+                top = TableOperation.Insert(row, true);
+            else
+                throw new Exception("Unknown write operation.");
+
+            return top;
+        }
+
+        private static TableResult WriteConditionalRow(IChainTable table, TableOperationType opType, ITableEntity row,
+            TableRequestOptions options = null, OperationContext oc = null)
+        {
+            try
+            {
+                TableOperation top = TranslateWriteOp(opType, row);
+                return table.Execute(top, options, oc);
+            }
+            catch (StorageException e)
+            {
+                return new TableResult() { Result = null, Etag = e.RequestInformation.Etag, HttpStatusCode = e.RequestInformation.HttpStatusCode };
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("TryWriteConditionalRow:Error: exception {0}", e);
+                return null;
+            }
+        }
+    }
+
+    class InternalOperation
+    {
+        internal InternalOperation(IChainTable target, TableOperation op, TableRequestOptions options = null, OperationContext context = null)
+        {
+            this.target = target;
+            this.op = op;
+            this.options = options;
+            this.context = context;
+        }
+
+        internal IChainTable target;
+        internal TableOperation op;
+        internal TableRequestOptions options;
+        internal OperationContext context;
+    }
+ 
+}

--- a/stable/STableLib/TableService.cs
+++ b/stable/STableLib/TableService.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.WindowsAzure.Storage.STable
+{
+    // A wrapper for IChainTableService, providing buffer of known tables
+    class TableService
+    {
+        internal TableService(ISTableConfig config, IChainTableService cs)
+        {
+            this.config = config;
+            this.cs = cs;
+        }
+
+        internal IChainTable GetHead()
+        {
+            return GetTable(config.GetHeadTableId());
+        }
+
+        internal IChainTable GetSnapshot(int ssid)
+        {
+            return GetTable(config.GetSnapshotTableId(ssid));
+        }
+
+
+
+        private ISTableConfig config;
+        private IChainTableService cs;
+        // buffer for involved IChainTables, we will ask CS if we cannot find a IChainTable here
+        private Dictionary<string, IChainTable> knownTables = new Dictionary<string, IChainTable>();
+
+
+
+        private IChainTable GetTable(string tableId)
+        {
+            if (knownTables.ContainsKey(tableId))
+                return knownTables[tableId];
+            else
+            {
+                var table = cs.GetChainTable(tableId);
+                knownTables[tableId] = table;
+                return table;
+            }
+        }
+    }
+}

--- a/stable/STableLib/app.config
+++ b/stable/STableLib/app.config
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/stable/STableLib/packages.config
+++ b/stable/STableLib/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />
+</packages>

--- a/stable/STableUnitTest/Properties/AssemblyInfo.cs
+++ b/stable/STableUnitTest/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("STableUnitTest")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("STableUnitTest")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2affe49c-7302-495d-843d-049076d3ec76")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/stable/STableUnitTest/STableUnitTest.csproj
+++ b/stable/STableUnitTest/STableUnitTest.csproj
@@ -1,0 +1,123 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{1CD204E9-2B5D-4015-9B36-17AE0BA7A1EB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>STableUnitTest</RootNamespace>
+    <AssemblyName>STableUnitTest</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Data.Edm, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.Edm.5.2.0\lib\net40\Microsoft.Data.Edm.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Data.OData, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\Microsoft.Data.OData.5.2.0\lib\net40\Microsoft.Data.OData.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=6.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\WindowsAzure.Storage.6.1.0\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Spatial, Version=5.6.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\packages\System.Spatial.5.2.0\lib\net40\System.Spatial.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="TestEntity.cs" />
+    <Compile Include="UnitTest1.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="User.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ChainTableFactory\ChainTableFactory.csproj">
+      <Project>{d34a9308-3f44-4c1c-942e-330bb766eabc}</Project>
+      <Name>ChainTableFactory</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\ChainTableInterface\ChainTableInterface.csproj">
+      <Project>{c24bc418-9bfd-48fa-94be-8dc8864c2ea6}</Project>
+      <Name>ChainTableInterface</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\..\library\Microsoft.Azure.Toolkit.Replication.csproj">
+      <Project>{0f6d71f2-1322-4b32-bb08-a6a99eb812d4}</Project>
+      <Name>Microsoft.Azure.Toolkit.Replication</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\STableLib\STableLib.csproj">
+      <Project>{5881cd5f-e467-497c-8a5b-46ac8b79a0b8}</Project>
+      <Name>STableLib</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/stable/STableUnitTest/TestEntity.cs
+++ b/stable/STableUnitTest/TestEntity.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace STableUnitTest
+{
+    class TestEntity : ITableEntity
+    {
+
+        public string PartitionKey { get; set; }
+
+        public string RowKey { get; set; }
+
+        public string ETag { get; set; }
+
+        public DateTimeOffset Timestamp { get; set; }
+
+        public TestEntity()
+        {
+            PartitionKey = "";
+            RowKey = "";
+            ETag = "";
+            d = ""; // no null value
+            Timestamp = DateTimeOffset.MinValue;
+        }
+
+        public TestEntity(string pKey, string rKey) : this()
+        {
+            PartitionKey = pKey;
+            RowKey = rKey;
+        }
+
+        public TestEntity(string pKey, string rKey, string eTag, DateTime time) : this()
+        {
+            PartitionKey = pKey;
+            RowKey = rKey;
+            ETag = eTag;
+            Timestamp = time;
+        }
+
+        // payload
+
+        public int a { get; set; }
+        public int b { get; set; }
+        public int c { get; set; }
+        public string d { get; set; }
+        public bool e { get; set; }
+        public double f { get; set; }
+
+        public void ReadEntity(IDictionary<string, EntityProperty> properties, Microsoft.WindowsAzure.Storage.OperationContext operationContext)
+        {
+            a = properties["a"].Int32Value.Value;
+            b = properties["b"].Int32Value.Value;
+            c = properties["c"].Int32Value.Value;
+            d = properties["d"].StringValue;
+            e = properties["e"].BooleanValue.Value;
+            f = properties["f"].DoubleValue.Value;
+        }
+
+
+
+        public IDictionary<string, EntityProperty> WriteEntity(Microsoft.WindowsAzure.Storage.OperationContext operationContext)
+        {
+            var res = new Dictionary<string, EntityProperty>();
+            res.Add("a", new EntityProperty(a));
+            res.Add("b", new EntityProperty(b));
+            res.Add("c", new EntityProperty(c));
+            res.Add("d", new EntityProperty(d));
+            res.Add("e", new EntityProperty(e));
+            res.Add("f", new EntityProperty(f));
+
+            return res;
+        }
+    }
+}

--- a/stable/STableUnitTest/UnitTest1.cs
+++ b/stable/STableUnitTest/UnitTest1.cs
@@ -1,0 +1,3808 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Storage.STable;
+using Microsoft.WindowsAzure.Storage.ChainTableFactory;
+using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.WindowsAzure.Storage.Table;
+using System.Net;
+using Microsoft.WindowsAzure.Storage;
+using System.Collections.Generic;
+using System.Threading;
+using System.IO;
+using System.Linq;
+
+namespace STableUnitTest
+{
+    [TestClass]
+    public class UnitTest1
+    {
+        private static readonly string configFile = "D:/config.txt";
+
+        [TestInitialize]
+        public void InitSTableTest()
+        {
+            name = "STable" + random.Next().ToString();
+            config = new DefaultSTableConfig(name, false);
+            ts = new DefaultChainTableService(configFile);
+            s = new STable(name, config, ts);
+        }
+
+        [TestCleanup]
+        public void CleanupSTableTest()
+        {
+            if (s != null)
+                s.DeleteIfExists();
+        }
+
+        [TestMethod]
+        public void CreateTabTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+        }
+
+        [TestMethod]
+        public void CreateTabExistTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            Assert.IsTrue(!DoCreateTable());
+            Assert.IsTrue(!DoCreateTable());
+        }
+
+        [TestMethod]
+        public void DeleteTabTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            Assert.IsTrue(DoDeleteTable());
+        }
+
+        [TestMethod]
+        public void DeleteTabNonExistTest()
+        {
+            Assert.IsTrue(!DoDeleteTable());
+            Assert.IsTrue(!DoDeleteTable());
+        }
+
+        [TestMethod]
+        public void InsertTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+            
+        }
+
+        [TestMethod]
+        public void InsertExistTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            try
+            {
+                res = DoInsert(entity);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict);
+            }
+        }
+
+        [TestMethod]
+        public void RetrieveTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity.ETag));
+            //Assert.IsTrue(ret.Timestamp.Equals(entity.Timestamp));
+            Assert.IsTrue(ret.a == entity.a && ret.a == 1);
+            Assert.IsTrue(ret.b == entity.b && ret.b == 2);
+            Assert.IsTrue(ret.c == entity.c && ret.c == 3);
+            Assert.IsTrue(ret.d.Equals(entity.d) && ret.d.Equals("hello world!"));
+            Assert.IsTrue(ret.e == entity.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity.f && ret.f == 123.45);
+        }
+
+        [TestMethod]
+        public void RetrieveNotExistTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            var retrieved = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved.Result == null);
+        }
+
+        [TestMethod]
+        public void RetrieveDeletedTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            res = DoDelete(entity);
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved.Result == null);
+        }
+
+        [TestMethod]
+        public void RetrieveInsertBackTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            res = DoDelete(entity);
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            entity.a = 555;
+            entity.d = "come back alive";
+            res = DoInsert(entity);
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity.ETag));
+            Assert.IsTrue(ret.a == entity.a && ret.a == 555);
+            Assert.IsTrue(ret.b == entity.b && ret.b == 2);
+            Assert.IsTrue(ret.c == entity.c && ret.c == 3);
+            Assert.IsTrue(ret.d.Equals(entity.d) && ret.d.Equals("come back alive"));
+            Assert.IsTrue(ret.e == entity.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity.f && ret.f == 123.45);
+        }
+
+
+        [TestMethod]
+        public void ReplaceTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 1;
+            entity2.b = 2;
+            entity2.c = 3;
+            entity2.d = "!dlrow olleh";
+            entity2.e = false;
+            entity2.f = 54.321;
+
+            entity2.ETag = entity.ETag;
+            entity2.Timestamp = entity.Timestamp;
+
+            var replaced = DoReplace(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(!replaced.Etag.Equals(entity.ETag));
+            Assert.IsTrue(replaced.Etag.Contains(","));
+            //Assert.IsTrue(entity2.Timestamp.Equals(entity.Timestamp));  // weird, replace does not change timestamp
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ret != entity2);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.Timestamp >= entity2.Timestamp);
+            Assert.IsTrue(ret.a == entity2.a && ret.a == 1);
+            Assert.IsTrue(ret.b == entity2.b && ret.b == 2);
+            Assert.IsTrue(ret.c == entity2.c && ret.c == 3);
+            Assert.IsTrue(ret.d.Equals(entity2.d) && ret.d.Equals("!dlrow olleh"));
+            Assert.IsTrue(ret.e == entity2.e && ret.e == false);
+            Assert.IsTrue(ret.f == entity2.f && ret.f == 54.321);
+        }
+
+        [TestMethod]
+        public void ReplaceStarTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 1;
+            entity2.b = 2;
+            entity2.c = 3;
+            entity2.d = "!dlrow olleh";
+            entity2.e = false;
+            entity2.f = 54.321;
+
+            entity2.ETag = "*";
+            entity2.Timestamp = entity.Timestamp;
+
+            var replaced = DoReplace(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(!replaced.Etag.Equals(entity.ETag));
+            Assert.IsTrue(replaced.Etag.Contains(","));
+            //Assert.IsTrue(entity2.Timestamp.Equals(entity.Timestamp));  // weird, replace does not change timestamp
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ret != entity2);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.Timestamp >= entity2.Timestamp);
+            Assert.IsTrue(ret.a == entity2.a);
+            Assert.IsTrue(ret.b == entity2.b);
+            Assert.IsTrue(ret.c == entity2.c);
+            Assert.IsTrue(ret.d.Equals(entity2.d));
+            Assert.IsTrue(ret.e == entity2.e);
+            Assert.IsTrue(ret.f == entity2.f);
+        }
+
+
+        [TestMethod]
+        public void ReplaceBadETagTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 1;
+            entity2.b = 2;
+            entity2.c = 3;
+            entity2.d = "!dlrow olleh";
+            entity2.e = false;
+            entity2.f = 54.321;
+
+            entity2.ETag = "0";
+            entity2.Timestamp = entity.Timestamp;
+
+            try
+            {
+                var replaced = DoReplace(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e != null && e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed);
+            }
+        }
+
+        [TestMethod]
+        public void ReplaceNullETagTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 1;
+            entity2.b = 2;
+            entity2.c = 3;
+            entity2.d = "!dlrow olleh";
+            entity2.e = false;
+            entity2.f = 54.321;
+
+            entity2.ETag = null;
+            entity2.Timestamp = entity.Timestamp;
+
+            try
+            {
+                var replaced = DoReplace(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (ArgumentException e)
+            {
+                Assert.IsTrue(e != null);
+            }
+        }
+
+        [TestMethod]
+        public void ReplaceNotExistTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            TestEntity entity2 = new TestEntity("2", "1");
+
+            entity2.a = 1;
+            entity2.b = 2;
+            entity2.c = 3;
+            entity2.d = "!dlrow olleh";
+            entity2.e = false;
+            entity2.f = 54.321;
+
+            entity2.ETag = entity.ETag;
+            entity2.Timestamp = entity.Timestamp;
+
+            try
+            {
+                var replaced = DoReplace(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e != null && e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+        }
+
+        [TestMethod]
+        public void MergeTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new DynamicTableEntity("1", "1");
+
+            entity2.Properties["a"] = new EntityProperty(1);
+            entity2.Properties["d"] = new EntityProperty("wow!");
+
+            entity2.ETag = entity.ETag;
+            entity2.Timestamp = DateTimeOffset.MinValue;
+
+            var replaced = DoMerge(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(!replaced.Etag.Equals(entity.ETag));
+            Assert.IsTrue(replaced.Etag.Contains(","));
+            //Assert.IsTrue(entity2.Timestamp.Equals(DateTimeOffset.MinValue));  // merge does not change timestamp
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ((ITableEntity)ret != (ITableEntity)entity2));
+            Assert.IsTrue(ret.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.Timestamp >= entity2.Timestamp && ret.Timestamp >= entity.Timestamp);
+            Assert.IsTrue(ret.a == 1);
+            Assert.IsTrue(ret.b == entity.b);
+            Assert.IsTrue(ret.c == entity.c);
+            Assert.IsTrue(ret.d.Equals("wow!"));
+            Assert.IsTrue(ret.e == entity.e);
+            Assert.IsTrue(ret.f == entity.f);
+        }
+
+        [TestMethod]
+        public void MergeStarTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new DynamicTableEntity("1", "1");
+
+            entity2.Properties["a"] = new EntityProperty(1);
+            entity2.Properties["d"] = new EntityProperty("wow!");
+
+            entity2.ETag = "*";
+
+            var replaced = DoMerge(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(!replaced.Etag.Equals(entity.ETag));
+            Assert.IsTrue(replaced.Etag.Contains(","));
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ((ITableEntity)ret != (ITableEntity)entity2));
+            Assert.IsTrue(ret.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.Timestamp >= entity2.Timestamp && ret.Timestamp >= entity.Timestamp);
+            Assert.IsTrue(ret.a == 1);
+            Assert.IsTrue(ret.b == entity.b);
+            Assert.IsTrue(ret.c == entity.c);
+            Assert.IsTrue(ret.d.Equals("wow!"));
+            Assert.IsTrue(ret.e == entity.e);
+            Assert.IsTrue(ret.f == entity.f);
+        }
+
+
+        [TestMethod]
+        public void MergeBadETagTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new DynamicTableEntity("1", "1");
+
+            entity2.Properties["a"] = new EntityProperty(1);
+            entity2.Properties["d"] = new EntityProperty("wow!");
+
+            entity2.ETag = "haha";
+
+            try
+            {
+                var replaced = DoMerge(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e != null && e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed);
+            }
+        }
+
+        [TestMethod]
+        public void MergeNotFoundTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new DynamicTableEntity("1", "a");
+
+            entity2.Properties["a"] = new EntityProperty(1);
+            entity2.Properties["d"] = new EntityProperty("wow!");
+
+            entity2.ETag = "haha";
+
+            try
+            {
+                var replaced = DoMerge(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e != null && e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+        }
+
+        [TestMethod]
+        public void DeleteTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.ETag = entity.ETag;
+            entity2.Timestamp = DateTimeOffset.MinValue;
+            entity2.a = 333;
+            entity2.d = "WTF";
+
+            var replaced = DoDelete(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(replaced.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity2.a == 333);
+            Assert.IsTrue(entity2.d.Equals("WTF"));
+            Assert.IsTrue(entity2.Timestamp == DateTimeOffset.MinValue);
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved.Result == null);
+        }
+
+        [TestMethod]
+        public void DeleteStarTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.ETag = "*";
+            entity2.Timestamp = DateTimeOffset.MinValue;
+            entity2.a = 333;
+            entity2.d = "WTF";
+
+            var replaced = DoDelete(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(replaced.Etag.Equals("*"));
+            Assert.IsTrue(entity2.a == 333);
+            Assert.IsTrue(entity2.d.Equals("WTF"));
+            Assert.IsTrue(entity2.Timestamp == DateTimeOffset.MinValue);
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved.Result == null);
+        }
+
+
+        [TestMethod]
+        public void DeleteBadETagTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.ETag = "*badetag*";
+            entity2.Timestamp = DateTimeOffset.MinValue;
+            entity2.a = 333;
+            entity2.d = "WTF";
+
+            try
+            {
+                var replaced = DoDelete(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e != null && e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed);
+            }
+        }
+
+        [TestMethod]
+        public void DeleteNotFoundTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new TestEntity("", "2");
+            entity2.ETag = "*";
+            entity2.Timestamp = DateTimeOffset.MinValue;
+            entity2.a = 333;
+            entity2.d = "WTF";
+
+            try
+            {
+                var replaced = DoDelete(entity2);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e != null && e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+        }
+
+        [TestMethod]
+        public void DeleteInsertTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 3;
+            entity.b = 2;
+            entity.c = 1;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.ETag = "*";
+            entity2.Timestamp = DateTimeOffset.MinValue;
+            entity2.a = 333;
+            entity2.d = "WTF";
+
+            var replaced = DoDelete(entity2);
+
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+            Assert.IsTrue(replaced.Result == entity2);
+            Assert.IsTrue(replaced.Etag.Equals(entity2.ETag));
+            Assert.IsTrue(replaced.Etag.Equals("*"));
+            Assert.IsTrue(entity2.a == 333);
+            Assert.IsTrue(entity2.d.Equals("WTF"));
+            Assert.IsTrue(entity2.Timestamp == DateTimeOffset.MinValue);
+
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved.Result == null);
+
+            TestEntity newEntity = new TestEntity("1", "1");
+            newEntity.a = 2;
+            newEntity.b = 3;
+            newEntity.c = 4;
+            newEntity.d = "reborn";
+            newEntity.e = false;
+            newEntity.f = 33.33;
+
+            var insertAgain = DoInsert(newEntity);
+            Assert.IsTrue(insertAgain != null && insertAgain.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(!insertAgain.Etag.Equals(entity.ETag) && !insertAgain.Etag.Equals(entity2.ETag));
+
+            var retrieveAgain = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieveAgain != null && retrieveAgain.HttpStatusCode == (int)HttpStatusCode.OK && retrieveAgain.Result != null);
+            Assert.IsTrue(retrieveAgain.Result is TestEntity);
+            var entity3 = (TestEntity)retrieveAgain.Result;
+            Assert.IsTrue(entity3 != newEntity);
+            Assert.IsTrue(entity3.a == newEntity.a);
+            Assert.IsTrue(entity3.b == newEntity.b);
+            Assert.IsTrue(entity3.c == newEntity.c);
+            Assert.IsTrue(entity3.d.Equals(newEntity.d));
+            Assert.IsTrue(entity3.e == newEntity.e);
+            Assert.IsTrue(entity3.f == newEntity.f);
+            // TODO: for delete -> insert, we changed it to replace, which will not return a valid timestamp...
+            //Assert.IsTrue(entity3.Timestamp == newEntity.Timestamp);
+            Assert.IsTrue(entity3.ETag.Equals(newEntity.ETag));
+        }
+
+        [TestMethod]
+        public void IORInsertTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            entity.Timestamp = DateTimeOffset.MinValue;
+
+            var res = DoIOR(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+            //Assert.IsTrue(entity.Timestamp.Equals(DateTimeOffset.MinValue));
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity.ETag));
+            Assert.IsTrue(ret.a == entity.a && ret.a == 1);
+            Assert.IsTrue(ret.b == entity.b && ret.b == 2);
+            Assert.IsTrue(ret.c == entity.c && ret.c == 3);
+            Assert.IsTrue(ret.d.Equals(entity.d) && ret.d.Equals("hello world!"));
+            Assert.IsTrue(ret.e == entity.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity.f && ret.f == 123.45);
+        }
+
+        [TestMethod]
+        public void IOMInsertTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            entity.Timestamp = DateTimeOffset.MinValue;
+
+            var res = DoIOM(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+            //Assert.IsTrue(entity.Timestamp.Equals(DateTimeOffset.MinValue));
+
+            var retrieved = DoRetrieve("1", "1");
+
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity.ETag));
+            Assert.IsTrue(ret.a == entity.a && ret.a == 1);
+            Assert.IsTrue(ret.b == entity.b && ret.b == 2);
+            Assert.IsTrue(ret.c == entity.c && ret.c == 3);
+            Assert.IsTrue(ret.d.Equals(entity.d) && ret.d.Equals("hello world!"));
+            Assert.IsTrue(ret.e == entity.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity.f && ret.f == 123.45);
+        }
+
+        [TestMethod]
+        public void IORReplaceTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+            entity2.a = 33;
+            entity2.b = 22;
+            entity2.c = 11;
+            entity2.d = "iorReplaced";
+            entity2.e = true;
+            entity2.f = 4444;
+
+            var replaced = DoIOR(entity2);
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ret != entity2);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.a == entity2.a && ret.a == 33);
+            Assert.IsTrue(ret.b == entity2.b && ret.b == 22);
+            Assert.IsTrue(ret.c == entity2.c && ret.c == 11);
+            Assert.IsTrue(ret.d.Equals(entity2.d) && ret.d.Equals("iorReplaced"));
+            Assert.IsTrue(ret.e == entity2.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity2.f && ret.f == 4444);
+        }
+
+        [TestMethod]
+        public void IOMMergeTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var entity2 = new DynamicTableEntity("1", "1");
+            entity2.Properties["a"] = new EntityProperty(33);
+            entity2.Properties["d"] = new EntityProperty("iomMerged");
+
+            var replaced = DoIOM(entity2);
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ((ITableEntity)ret != (ITableEntity)entity2));
+            Assert.IsTrue(ret.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.a == 33);
+            Assert.IsTrue(ret.b == 2);
+            Assert.IsTrue(ret.c ==3);
+            Assert.IsTrue(ret.d.Equals("iomMerged"));
+            Assert.IsTrue(ret.e == true);
+            Assert.IsTrue(ret.f == 123.45);
+        }
+
+        [TestMethod]
+        public void IORInsertDeletedTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var deleted = DoDelete(entity);
+            Assert.IsTrue(deleted != null && deleted.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+            entity2.a = 33;
+            entity2.b = 22;
+            entity2.c = 11;
+            entity2.d = "iorInsertDeleted";
+            entity2.e = true;
+            entity2.f = 4444;
+
+            var replaced = DoIOR(entity2);
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ret != entity2);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.a == entity2.a && ret.a == 33);
+            Assert.IsTrue(ret.b == entity2.b && ret.b == 22);
+            Assert.IsTrue(ret.c == entity2.c && ret.c == 11);
+            Assert.IsTrue(ret.d.Equals(entity2.d) && ret.d.Equals("iorInsertDeleted"));
+            Assert.IsTrue(ret.e == entity2.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity2.f && ret.f == 4444);
+        }
+
+        [TestMethod]
+        public void IOMInsertDeletedTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var deleted = DoDelete(entity);
+            Assert.IsTrue(deleted != null && deleted.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+            entity2.a = 33;
+            entity2.b = 22;
+            entity2.c = 11;
+            entity2.d = "iomInsertDeleted";
+            entity2.e = true;
+            entity2.f = 4444;
+
+            var replaced = DoIOM(entity2);
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved != null && retrieved.HttpStatusCode == (int)HttpStatusCode.OK && retrieved.Result != null);
+            Assert.IsTrue(retrieved.Result is TestEntity);
+            var ret = (TestEntity)retrieved.Result;
+            Assert.IsTrue(ret.ETag.Equals(retrieved.Etag));
+
+            Assert.IsTrue(ret != entity && ret != entity2);
+            Assert.IsTrue(ret.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.a == entity2.a && ret.a == 33);
+            Assert.IsTrue(ret.b == entity2.b && ret.b == 22);
+            Assert.IsTrue(ret.c == entity2.c && ret.c == 11);
+            Assert.IsTrue(ret.d.Equals(entity2.d) && ret.d.Equals("iomInsertDeleted"));
+            Assert.IsTrue(ret.e == entity2.e && ret.e == true);
+            Assert.IsTrue(ret.f == entity2.f && ret.f == 4444);
+        }
+
+        [TestMethod]
+        public void CreateSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid = DoCreateSnapshot();
+            Assert.IsTrue(ssid == 0);
+        }
+
+        [TestMethod]
+        public void ReadSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid = DoCreateSnapshot();
+            Assert.IsTrue(ssid == 0);
+
+
+            var retrieved1 = DoRetrieveSnapshot(ssid, "1", "1");
+
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            Assert.IsTrue(retrieved1.Result is TestEntity);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag.Equals(retrieved1.Etag));
+
+            Assert.IsTrue(ret1 != entity);
+            Assert.IsTrue(ret1.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret1.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret1.ETag.Equals(entity.ETag));
+            // TODO: COW to snapshot table kills the original timestamp, is this ok?
+            //Assert.IsTrue(ret1.Timestamp.Equals(entity.Timestamp));
+            Assert.IsTrue(ret1.a == entity.a && ret1.a == 1);
+            Assert.IsTrue(ret1.b == entity.b && ret1.b == 2);
+            Assert.IsTrue(ret1.c == entity.c && ret1.c == 3);
+            Assert.IsTrue(ret1.d.Equals(entity.d) && ret1.d.Equals("hello world!"));
+            Assert.IsTrue(ret1.e == entity.e && ret1.e == true);
+            Assert.IsTrue(ret1.f == entity.f && ret1.f == 123.45);
+        }
+
+        [TestMethod]
+        public void ReadInvalidSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+
+            try
+            {
+                var retrieved1 = DoRetrieveSnapshot(2, "1", "1");
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.BadRequest);
+            }
+
+            try
+            {
+                var retrieved1 = DoRetrieveSnapshot(3, "1", "1");
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.BadRequest);
+            }
+        }
+
+        [TestMethod]
+        public void ReadSnapshotNotExistRowTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid = DoCreateSnapshot();
+            Assert.IsTrue(ssid == 0);
+
+
+            var retrieved1 = DoRetrieveSnapshot(ssid, "1", "2");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved1.Result == null);
+
+
+            TestEntity entity2 = new TestEntity("1", "2");
+
+            entity2.a = 3;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res2 = DoInsert(entity2);
+            Assert.IsTrue(res2 != null);
+            Assert.IsTrue(res2.HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var retrieved2 = DoRetrieveSnapshot(ssid, "1", "2");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved2.Result == null);
+        }
+
+        [TestMethod]
+        public void ReadSnapshotHistoryNotExistTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            var ssid = DoCreateSnapshot();
+            Assert.IsTrue(ssid == 0);
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+
+            var retrieved1 = DoRetrieveSnapshot(ssid, "1", "2");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved1.Result == null);
+
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 3;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+            entity2.ETag = entity.ETag;
+
+            var res2 = DoReplace(entity2);
+            Assert.IsTrue(res2 != null);
+            Assert.IsTrue(res2.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved2 = DoRetrieveSnapshot(ssid, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.NotFound && retrieved2.Result == null);
+
+            ssid = DoCreateSnapshot();
+
+            var retrieved3 = DoRetrieveSnapshot(ssid, "1", "1");
+            Assert.IsTrue(retrieved3 != null && retrieved3.HttpStatusCode == (int)HttpStatusCode.OK && retrieved3.Result != null);
+            var ret = (TestEntity)retrieved3.Result;
+            Assert.IsTrue(ret.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret.a == 3);
+            Assert.IsTrue(ret.b == 3);
+            Assert.IsTrue(ret.c == 3);
+            Assert.IsTrue(ret.d.Equals("hello world!"));
+            Assert.IsTrue(ret.e == true);
+            Assert.IsTrue(ret.f == 323.45);
+        }
+
+        [TestMethod]
+        public void ReadSnapshotUpdatedRowTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 1;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid = DoCreateSnapshot();
+            Assert.IsTrue(ssid == 0);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 5;
+            entity2.b = 5;
+            entity2.c = 5;
+            entity2.d = "!dlrow olleh";
+            entity2.e = false;
+            entity2.f = 54.321;
+
+            entity2.ETag = entity.ETag;
+
+            var replaced = DoReplace(entity2);
+            Assert.IsTrue(replaced != null && replaced.HttpStatusCode == (int)HttpStatusCode.NoContent && replaced.Result != null);
+
+            var retrieved1 = DoRetrieveSnapshot(ssid, "1", "1");
+
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            Assert.IsTrue(retrieved1.Result is TestEntity);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag.Equals(retrieved1.Etag));
+
+            Assert.IsTrue(ret1 != entity && ret1 != entity2);
+            Assert.IsTrue(ret1.PartitionKey.Equals(entity.PartitionKey));
+            Assert.IsTrue(ret1.RowKey.Equals(entity.RowKey));
+            Assert.IsTrue(ret1.ETag.Equals(entity.ETag));
+            // TODO: COW to snapshot table kills the original timestamp, is this ok?
+            //Assert.IsTrue(ret1.Timestamp.Equals(entity.Timestamp));
+            Assert.IsTrue(ret1.a == entity.a && ret1.a == 1);
+            Assert.IsTrue(ret1.b == entity.b && ret1.b == 2);
+            Assert.IsTrue(ret1.c == entity.c && ret1.c == 3);
+            Assert.IsTrue(ret1.d.Equals(entity.d) && ret1.d.Equals("hello world!"));
+            Assert.IsTrue(ret1.e == entity.e && ret1.e == true);
+            Assert.IsTrue(ret1.f == entity.f && ret1.f == 123.45);
+
+
+            var retrieved2 = DoRetrieve("1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.OK && retrieved2.Result != null);
+            Assert.IsTrue(retrieved2.Result is TestEntity);
+            var ret2 = (TestEntity)retrieved2.Result;
+            Assert.IsTrue(ret2.ETag.Equals(retrieved2.Etag));
+
+            Assert.IsTrue(ret2 != entity && ret2 != entity2);
+            Assert.IsTrue(ret2.PartitionKey.Equals(entity2.PartitionKey));
+            Assert.IsTrue(ret2.RowKey.Equals(entity2.RowKey));
+            Assert.IsTrue(ret2.ETag.Equals(entity2.ETag));
+            Assert.IsTrue(ret2.a == entity2.a && ret2.a == 5);
+            Assert.IsTrue(ret2.b == entity2.b && ret2.b == 5);
+            Assert.IsTrue(ret2.c == entity2.c && ret2.c == 5);
+            Assert.IsTrue(ret2.d.Equals(entity2.d) && ret2.d.Equals("!dlrow olleh"));
+            Assert.IsTrue(ret2.e == entity2.e && ret2.e == false);
+            Assert.IsTrue(ret2.f == entity2.f && ret2.f == 54.321);
+        }
+
+        [TestMethod]
+        public void ReadSnapshotJumpTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            TestEntity entity2 = new TestEntity("1", "1");
+
+            entity2.a = 2;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+            entity2.ETag = entity.ETag;
+
+            var res2 = DoReplace(entity2);
+            Assert.IsTrue(res2 != null);
+            Assert.IsTrue(res2.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            var ssid3 = DoCreateSnapshot();
+            Assert.IsTrue(ssid3 == 3);
+
+            var ssid4 = DoCreateSnapshot();
+            Assert.IsTrue(ssid4 == 4);
+
+            var retrieved1 = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag == entity.ETag && ret1.a == 0); // ignore other check
+
+            TestEntity entity3 = new TestEntity("1", "1");
+
+            entity3.a = 5;
+            entity3.b = 3;
+            entity3.c = 3;
+            entity3.d = "hello world!";
+            entity3.e = true;
+            entity3.f = 323.45;
+            entity3.ETag = entity2.ETag;
+
+            var res3 = DoReplace(entity3);
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var retrieved2 = DoRetrieveSnapshot(ssid4, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.OK && retrieved2.Result != null);
+            var ret2 = (TestEntity)retrieved2.Result;
+            Assert.IsTrue(ret2.ETag == entity2.ETag && ret2.a == 2); // ignore other check
+
+            var retrieved3 = DoRetrieveSnapshot(ssid4, "1", "1");
+            Assert.IsTrue(retrieved3 != null && retrieved3.HttpStatusCode == (int)HttpStatusCode.OK && retrieved3.Result != null);
+            var ret3 = (TestEntity)retrieved3.Result;
+            Assert.IsTrue(ret3.ETag == entity2.ETag && ret3.a == 2); // ignore other check
+        }
+
+
+        [TestMethod]
+        public void ReadSnapshotDeleteInsertTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 2;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            var ssid3 = DoCreateSnapshot();
+            Assert.IsTrue(ssid3 == 3);
+
+            TestEntity dEntity = new TestEntity("1", "1");
+            dEntity.ETag = entity.ETag;
+            var res2 = DoDelete(dEntity);
+            Assert.IsTrue(res2 != null && res2.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var ssid4 = DoCreateSnapshot();
+            Assert.IsTrue(ssid4 == 4);
+
+            var ssid5 = DoCreateSnapshot();
+            Assert.IsTrue(ssid5 == 5);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 6;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var ssid6 = DoCreateSnapshot();
+            Assert.IsTrue(ssid6 == 6);
+
+            var ssid7 = DoCreateSnapshot();
+            Assert.IsTrue(ssid7 == 7);
+
+
+            var entity3 = new TestEntity("1", "1");
+            entity3.a = 8;
+            entity3.b = 3;
+            entity3.c = 3;
+            entity3.d = "hello world!";
+            entity3.e = true;
+            entity3.f = 323.45;
+            entity3.ETag = entity2.ETag;
+
+            var res4 = DoReplace(entity3);
+            Assert.IsTrue(res4 != null);
+            Assert.IsTrue(res4.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+
+            var retrieved1 = DoRetrieveSnapshot(ssid4, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            var retrieved2 = DoRetrieveSnapshot(ssid5, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            var retrieved3 = DoRetrieveSnapshot(ssid6, "1", "1");
+            Assert.IsTrue(retrieved3 != null && retrieved3.HttpStatusCode == (int)HttpStatusCode.OK && retrieved3.Result != null);
+            var ret3 = (TestEntity)retrieved3.Result;
+            Assert.IsTrue(ret3.ETag == entity2.ETag && ret3.a == 6); // ignore other check
+
+            var retrieved4 = DoRetrieveSnapshot(ssid7, "1", "1");
+            Assert.IsTrue(retrieved4 != null && retrieved4.HttpStatusCode == (int)HttpStatusCode.OK && retrieved4.Result != null);
+            var ret4 = (TestEntity)retrieved4.Result;
+            Assert.IsTrue(ret4.ETag == entity2.ETag && ret4.a == 6); // ignore other check
+
+            var retrieved5 = DoRetrieveSnapshot(ssid3, "1", "1");
+            Assert.IsTrue(retrieved5 != null && retrieved5.HttpStatusCode == (int)HttpStatusCode.OK && retrieved5.Result != null);
+            var ret5 = (TestEntity)retrieved5.Result;
+            Assert.IsTrue(ret5.ETag == entity.ETag && ret5.a == 2); // ignore other check
+
+            var retrieved6 = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(retrieved6 != null && retrieved6.HttpStatusCode == (int)HttpStatusCode.NotFound);
+        }
+
+        [TestMethod]
+        public void DeleteSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 2;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            DoDeleteSnapshot(ssid0);
+
+            var retrieved1 = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag == entity.ETag && ret1.a == 0); // ignore other check
+
+            var ssid2 = DoCreateSnapshot();
+
+            var retrieved2 = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.OK && retrieved2.Result != null);
+            var ret2 = (TestEntity)retrieved2.Result;
+            Assert.IsTrue(ret2.ETag == entity2.ETag && ret2.a == 2); // ignore other check
+        }
+
+        [TestMethod]
+        public void DeleteSnapshotStopPushTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 1;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            DoDeleteSnapshot(ssid0);
+
+            var retrieved1 = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag == entity2.ETag && ret1.a == 1); // ignore other check
+        }
+
+        [TestMethod]
+        public void DeleteSnapshotPushAcrossHoleTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 3;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            DoDeleteSnapshot(ssid1);
+            DoDeleteSnapshot(ssid0);    // need to push across ssid1 to ssid2
+
+            var retrieved1 = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag == entity.ETag && ret1.a == 0); // ignore other check
+        }
+
+        [TestMethod]
+        public void COWPushAcrossDeletedSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            DoDeleteSnapshot(ssid1);
+            DoDeleteSnapshot(ssid0);
+
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 3;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);      // need to push old content to snapshot 2 (0 & 1 deleted)
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+
+
+            var retrieved1 = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag == entity.ETag && ret1.a == 0); // ignore other check
+        }
+
+        [TestMethod]
+        public void COWCancelledDueToDeletedSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            DoDeleteSnapshot(ssid1);
+            DoDeleteSnapshot(ssid0);
+
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 2;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);      // plan to cow old data to 0, but cancelled since there are no valid snapshot from 0 to Curr -1 
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            var retrieved1 = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.OK && retrieved1.Result != null);
+            var ret1 = (TestEntity)retrieved1.Result;
+            Assert.IsTrue(ret1.ETag == entity2.ETag && ret1.a == 2); // ignore other check
+        }
+
+        [TestMethod]
+        public void ReadDeleteSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 0;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            DoDeleteSnapshot(ssid0);
+
+            try
+            {
+                var retrieved1 = DoRetrieveSnapshot(ssid0, "1", "1");
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e.RequestInformation.HttpStatusCode == (int)HttpStatusCode.BadRequest);
+            }
+
+            var retrieved2 = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.OK);
+            var ret2 = (TestEntity)retrieved2.Result;
+            Assert.IsTrue(ret2.ETag.Equals(entity.ETag) && ret2.a == 0);
+        }
+
+        [TestMethod]
+        public void ReadSnapshotJumpWithDeleteSnapshotTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            DoDeleteSnapshot(ssid0);
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 2;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            var ssid3 = DoCreateSnapshot();
+            Assert.IsTrue(ssid3 == 3);
+
+            DoDeleteSnapshot(ssid3);
+
+            TestEntity dEntity = new TestEntity("1", "1");
+            dEntity.ETag = entity.ETag;
+            var res2 = DoDelete(dEntity);
+            Assert.IsTrue(res2 != null && res2.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var ssid4 = DoCreateSnapshot();
+            Assert.IsTrue(ssid4 == 4);
+
+            var ssid5 = DoCreateSnapshot();
+            Assert.IsTrue(ssid5 == 5);
+
+            DoDeleteSnapshot(ssid4);
+
+            var entity2 = new TestEntity("1", "1");
+            entity2.a = 6;
+            entity2.b = 3;
+            entity2.c = 3;
+            entity2.d = "hello world!";
+            entity2.e = true;
+            entity2.f = 323.45;
+
+            var res3 = DoIOR(entity2);
+            Assert.IsTrue(res3 != null);
+            Assert.IsTrue(res3.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            var ssid6 = DoCreateSnapshot();
+            Assert.IsTrue(ssid6 == 6);
+
+            var ssid7 = DoCreateSnapshot();
+            Assert.IsTrue(ssid7 == 7);
+            
+            var ssid8 = DoCreateSnapshot();
+            Assert.IsTrue(ssid8 == 8);
+
+            DoDeleteSnapshot(ssid7);
+
+            var entity3 = new TestEntity("1", "1");
+            entity3.a = 9;
+            entity3.b = 3;
+            entity3.c = 3;
+            entity3.d = "hello world!";
+            entity3.e = true;
+            entity3.f = 323.45;
+            entity3.ETag = entity2.ETag;
+
+            var res4 = DoReplace(entity3);
+            Assert.IsTrue(res4 != null);
+            Assert.IsTrue(res4.HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+
+            var retrieved1 = DoRetrieveSnapshot(ssid5, "1", "1");
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            var retrieved2 = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.OK && retrieved2.Result != null);
+            var ret2 = (TestEntity)retrieved2.Result;
+            Assert.IsTrue(ret2.ETag == entity.ETag && ret2.a == 2); // ignore other check
+
+            var retrieved3 = DoRetrieveSnapshot(ssid8, "1", "1");
+            Assert.IsTrue(retrieved3 != null && retrieved3.HttpStatusCode == (int)HttpStatusCode.OK && retrieved3.Result != null);
+            var ret3 = (TestEntity)retrieved3.Result;
+            Assert.IsTrue(ret3.ETag == entity2.ETag && ret3.a == 6); // ignore other check
+
+            var retrieved4 = DoRetrieveSnapshot(ssid6, "1", "1");
+            Assert.IsTrue(retrieved4 != null && retrieved4.HttpStatusCode == (int)HttpStatusCode.OK && retrieved4.Result != null);
+            var ret4 = (TestEntity)retrieved4.Result;
+            Assert.IsTrue(ret4.ETag == entity2.ETag && ret4.a == 6); // ignore other check
+
+            var retrieved5 = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(retrieved5 != null && retrieved5.HttpStatusCode == (int)HttpStatusCode.NotFound);
+        }
+
+        [TestMethod]
+        public void DeleteSnapshotGCTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            var ssid0 = DoCreateSnapshot();
+            Assert.IsTrue(ssid0 == 0);
+
+            var ssid1 = DoCreateSnapshot();
+            Assert.IsTrue(ssid1 == 1);
+
+            TestEntity entity = new TestEntity("1", "1");
+
+            entity.a = 2;
+            entity.b = 2;
+            entity.c = 3;
+            entity.d = "hello world!";
+            entity.e = true;
+            entity.f = 123.45;
+
+            var res = DoInsert(entity);
+            Assert.IsTrue(res != null);
+            Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(res.Result == entity);
+            Assert.IsTrue(res.Etag.Equals(entity.ETag));
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid2 = DoCreateSnapshot();
+            Assert.IsTrue(ssid2 == 2);
+
+            var ssid3 = DoCreateSnapshot();
+            Assert.IsTrue(ssid3 == 3);
+
+            TestEntity dEntity = new TestEntity("1", "1");
+            dEntity.ETag = entity.ETag;
+            var res2 = DoDelete(dEntity);
+            Assert.IsTrue(res2 != null && res2.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            
+            var ssid4 = DoCreateSnapshot();
+            Assert.IsTrue(ssid4 == 4);
+
+            var ssid5 = DoCreateSnapshot();
+            Assert.IsTrue(ssid5 == 5);
+
+            var retrieved1 = DoRetrieveSnapshot(ssid5, "1", "1");   // will push the deleted row to table ss_5
+            Assert.IsTrue(retrieved1 != null && retrieved1.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            DoDeleteSnapshot(ssid4);
+
+            DoGC(); // should not delete the row
+
+            var retrieved2 = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(retrieved2 != null && retrieved2.HttpStatusCode == (int)HttpStatusCode.OK && retrieved2.Result != null);
+            var ret2 = (TestEntity)retrieved2.Result;
+            Assert.IsTrue(ret2.ETag == entity.ETag && ret2.a == 2); // ignore other check
+
+            var retrieved3 = DoRetrieveSnapshot(ssid1, "1", "1");    // this will create a deleted dummy row in ss_1
+            Assert.IsTrue(retrieved3 != null && retrieved3.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            DoDeleteSnapshot(ssid2);
+
+            DoGC(); // should not delete the row
+
+            var retrieved4 = DoRetrieveSnapshot(ssid3, "1", "1");
+            Assert.IsTrue(retrieved4 != null && retrieved4.HttpStatusCode == (int)HttpStatusCode.OK && retrieved4.Result != null);
+            var ret4 = (TestEntity)retrieved4.Result;
+            Assert.IsTrue(ret4.ETag == entity.ETag && ret4.a == 2); // ignore other check
+
+            DoDeleteSnapshot(ssid3);    // now, the row is marked as "deleted" in all tables
+
+            var headTab = ts.GetChainTable(config.GetHeadTableId());
+            var ss1 = ts.GetChainTable(config.GetSnapshotTableId(ssid1));
+
+            var acc = headTab.Execute(TableOperation.Retrieve<DynamicTableEntity>("1", "1"));
+            Assert.IsTrue(acc != null && acc.HttpStatusCode == (int)HttpStatusCode.OK);
+
+            acc = ss1.Execute(TableOperation.Retrieve<DynamicTableEntity>("1", "1"));
+            Assert.IsTrue(acc != null && acc.HttpStatusCode == (int)HttpStatusCode.OK);
+
+            DoGC(); // should delete the row
+
+            acc = headTab.Execute(TableOperation.Retrieve<DynamicTableEntity>("1", "1"));
+            Assert.IsTrue(acc != null && acc.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            acc = ss1.Execute(TableOperation.Retrieve<DynamicTableEntity>("1", "1"));
+            Assert.IsTrue(acc != null && acc.HttpStatusCode == (int)HttpStatusCode.NotFound);
+        }
+
+        [TestMethod]
+        public void BatchSimpleOpTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            // test insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+                entities[i].ETag = "useless";
+                entities[i].Timestamp = DateTimeOffset.MinValue;
+            }
+
+            var batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                batch.Add(TableOperation.Insert(entities[i]));
+            }
+
+            var resList1 = DoExecuteBatch(batch);
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                Assert.IsTrue(resList1[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+                //Assert.IsTrue(entities[i].Timestamp != DateTimeOffset.MinValue);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.OK && ret.Result != null);
+                var ent = (TestEntity)ret.Result;
+                Assert.IsTrue(entities[i].ETag.Equals(ent.ETag));
+                //Assert.IsTrue(entities[i].Timestamp.Equals(ent.Timestamp));
+            }
+
+            // test replace / merge / ior / iom
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i].a = i * 2;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    batch.Add(TableOperation.Replace(entities[i]));
+                else if (i % 4 == 1)
+                    batch.Add(TableOperation.Merge(entities[i]));
+                else if (i % 4 == 2)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 4 == 3)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList2 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList2 != null && resList2.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                Assert.IsTrue(resList2[i] != null && resList2[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList2[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.OK && ret.Result != null);
+                var ent = (TestEntity)ret.Result;
+                Assert.IsTrue(ent.a == i * 2);
+                Assert.IsTrue(ent.ETag.Equals(entities[i].ETag));
+            }
+
+            // test delete
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+                batch.Add(TableOperation.Delete(entities[i]));
+
+            var resList3 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList3 != null && resList3.Count == 10);
+            for (int i = 0; i < 10; ++i)
+                Assert.IsTrue(resList3[i] != null && resList3[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            // test insert back
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i].a = i * 3;
+                entities[i].d = "wow!" + i.ToString();
+                entities[i].ETag = "";
+
+                if (i % 3 == 0)
+                    batch.Add(TableOperation.Insert(entities[i]));
+                else if (i % 3 == 1)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 3 == 2)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList4 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList4 != null && resList4.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.OK && ret.Result != null);
+                var ent = (TestEntity)ret.Result;
+                Assert.IsTrue(ent.a == i * 3);
+                Assert.IsTrue(ent.ETag.Equals(entities[i].ETag));
+            }
+
+            // test retrieve
+            batch = new TableBatchOperation();
+            batch.Add(TableOperation.Retrieve<TestEntity>("1", "1"));
+            var resList5 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList5 != null && resList5.Count == 1);
+            Assert.IsTrue(resList5[0] != null && resList5[0].HttpStatusCode == (int)HttpStatusCode.OK && resList5[0].Result != null);
+            Assert.IsTrue(resList5[0].Etag.Equals(entities[1].ETag));
+        }
+
+        [TestMethod]
+        public void BatchErrorReturnTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            // insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+            }
+
+            var batch = new TableBatchOperation();
+            for (int i = 0; i < 5; ++i)
+            {
+                batch.Add(TableOperation.Insert(entities[i]));
+            }
+
+            var resList = DoExecuteBatch(batch);
+
+            Assert.IsTrue(resList != null && resList.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList[i] != null && resList[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                Assert.IsTrue(resList[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+
+            // Case 1: insert over existing entities
+            batch = new TableBatchOperation();
+            for (int i = 5; i < 10; ++i)
+                batch.Add(TableOperation.Insert(entities[i]));
+            
+            entities[0].a = 555;
+            batch.Add(TableOperation.Insert(entities[0]));
+
+            try
+            {
+                resList = DoExecuteBatch(batch);
+                Assert.IsTrue(false);
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e is ChainTableBatchException);
+                var ee = (ChainTableBatchException)e;
+                Assert.IsTrue(ee.FailedOpIndex == 5 && ee.RequestInformation.HttpStatusCode == (int)HttpStatusCode.Conflict);
+            }
+
+            entities[0].a = 0;
+
+            // should rollback any change
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                if (i < 5)
+                {
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                    var raw = (TestEntity)res.Result;
+                    Assert.IsTrue(raw.a == i);
+                }
+                else
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+
+            // Case 2: replace / merge / delete with wrong etag
+            for (int i = 0; i < 5; ++i)
+                entities[i].a = 2 * i;
+
+            for (int t = 1; t < 4; ++t)
+            {
+                // t = 1, test merge; t = 2, test delete; t = 3, test replace
+                var etagBackup = entities[t].ETag;
+                entities[t].ETag = "wrong etag";
+
+                batch = new TableBatchOperation();
+                for (int i = 0; i < 5; ++i)
+                {
+                    if (i % 3 == 0)
+                        batch.Add(TableOperation.Replace(entities[i]));
+                    else if (i % 3 == 1)
+                        batch.Add(TableOperation.Merge(entities[i]));
+                    else
+                        batch.Add(TableOperation.Delete(entities[i]));
+                }
+
+                try
+                {
+                    resList = DoExecuteBatch(batch);
+                    Assert.IsTrue(false);
+                }
+                catch (StorageException e)
+                {
+                    Assert.IsTrue(e is ChainTableBatchException);
+                    var ee = (ChainTableBatchException)e;
+                    Assert.IsTrue(ee.FailedOpIndex == t && ee.RequestInformation.HttpStatusCode == (int)HttpStatusCode.PreconditionFailed);
+                }
+
+                // should rollback any change
+                for (int i = 0; i < 5; ++i)
+                {
+                    var res = DoRetrieve("1", i.ToString());
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                    var raw = (TestEntity)res.Result;
+                    Assert.IsTrue(raw.a == i);
+                }
+
+                entities[t].ETag = etagBackup;
+            }
+
+
+            // Case 3: replace / merge / delete with nonexisting row
+            for (int i = 0; i < 10; ++i)
+                entities[i].a = 3 * i;
+
+            for (int i = 5; i < 10; ++i)
+                entities[i].ETag = "useless etag";
+
+            for (int t = 0; t < 3; ++t)
+            {
+                // t = 0, test replace; t = 1, test merge; t = 2, test delete;
+
+                batch = new TableBatchOperation();
+                for (int i = 0; i < 5; ++i)
+                {
+                    if (i % 3 == 0)
+                        batch.Add(TableOperation.Replace(entities[i]));
+                    else if (i % 3 == 1)
+                        batch.Add(TableOperation.Merge(entities[i]));
+                    else
+                        batch.Add(TableOperation.Delete(entities[i]));
+                }
+
+                if (t == 0)
+                    batch.Add(TableOperation.Replace(entities[6]));
+                else if (t == 1)
+                    batch.Add(TableOperation.Merge(entities[7]));
+                else
+                    batch.Add(TableOperation.Delete(entities[8]));
+
+                try
+                {
+                    resList = DoExecuteBatch(batch);
+                    Assert.IsTrue(false);
+                }
+                catch (StorageException e)
+                {
+                    Assert.IsTrue(e is ChainTableBatchException);
+                    var ee = (ChainTableBatchException)e;
+                    Assert.IsTrue(ee.FailedOpIndex == 5 && ee.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound);
+                }
+
+                // should rollback any change
+                for (int i = 0; i < 10; ++i)
+                {
+                    var res = DoRetrieve("1", i.ToString());
+                    if (i < 5)
+                    {
+                        Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                        var raw = (TestEntity)res.Result;
+                        Assert.IsTrue(raw.a == i);
+                    }
+                    else
+                        Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+                }
+            }
+
+
+            // Case 4: replace / merge / delete with deleted row
+            for (int i = 0; i < 10; ++i)
+                entities[i].a = 4 * i;
+
+            for (int i = 5; i < 10; ++i)
+            {
+                var res = DoInsert(entities[i]);
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.Created);
+
+                res = DoDelete(entities[i]);
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            }
+
+            for (int t = 0; t < 3; ++t)
+            {
+                // t = 0, test replace; t = 1, test merge; t = 2, test delete;
+
+                batch = new TableBatchOperation();
+                for (int i = 0; i < 5; ++i)
+                {
+                    if (i % 3 == 0)
+                        batch.Add(TableOperation.Replace(entities[i]));
+                    else if (i % 3 == 1)
+                        batch.Add(TableOperation.Merge(entities[i]));
+                    else
+                        batch.Add(TableOperation.Delete(entities[i]));
+                }
+
+                if (t == 0)
+                    batch.Add(TableOperation.Replace(entities[6]));
+                else if (t == 1)
+                    batch.Add(TableOperation.Merge(entities[7]));
+                else
+                    batch.Add(TableOperation.Delete(entities[8]));
+
+                try
+                {
+                    resList = DoExecuteBatch(batch);
+                    Assert.IsTrue(false);
+                }
+                catch (StorageException e)
+                {
+                    Assert.IsTrue(e is ChainTableBatchException);
+                    var ee = (ChainTableBatchException)e;
+                    Assert.IsTrue(ee.FailedOpIndex == 5 && ee.RequestInformation.HttpStatusCode == (int)HttpStatusCode.NotFound);
+                }
+
+                // should rollback any change
+                for (int i = 0; i < 10; ++i)
+                {
+                    var res = DoRetrieve("1", i.ToString());
+                    if (i < 5)
+                    {
+                        Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                        var raw = (TestEntity)res.Result;
+                        Assert.IsTrue(raw.a == i);
+                    }
+                    else
+                        Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+                }
+            }
+
+            // Case 5: retrieve in non-trivial batch, this is prohibitted by batch.Add()
+        }
+
+        [TestMethod]
+        public void BatchCOWTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            // insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+            }
+
+            var batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                batch.Add(TableOperation.Insert(entities[i]));
+            }
+
+            var resList1 = DoExecuteBatch(batch);
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                Assert.IsTrue(resList1[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid0 = DoCreateSnapshot();
+            
+            // test replace / merge / ior / iom
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 5; ++i)
+            {
+                entities[i].a = i * 2;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    batch.Add(TableOperation.Replace(entities[i]));
+                else if (i % 4 == 1)
+                    batch.Add(TableOperation.Merge(entities[i]));
+                else if (i % 4 == 2)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 4 == 3)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList2 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList2 != null && resList2.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList2[i] != null && resList2[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList2[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid1 = DoCreateSnapshot();
+
+            // test delete
+            batch = new TableBatchOperation();
+            for (int i = 5; i < 10; ++i)
+                batch.Add(TableOperation.Delete(entities[i]));
+
+            var resList3 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList3 != null && resList3.Count == 5);
+            for (int i = 0; i < 5; ++i)
+                Assert.IsTrue(resList3[i] != null && resList3[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            for (int i = 5; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            var ssid2 = DoCreateSnapshot();
+            
+            // test insert back
+            batch = new TableBatchOperation();
+            for (int i = 5; i < 10; ++i)
+            {
+                entities[i].a = i * 3;
+                entities[i].d = "wow!" + i.ToString();
+                entities[i].ETag = "";
+
+                if (i % 3 == 0)
+                    batch.Add(TableOperation.Insert(entities[i]));
+                else if (i % 3 == 1)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 3 == 2)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList4 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList4 != null && resList4.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                if ((5 + i) % 3 == 0)
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid3 = DoCreateSnapshot();
+
+            // check
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid0, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid1, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i < 5)
+                    Assert.IsTrue(raw.a == 2 * i);
+                else
+                    Assert.IsTrue(raw.a == i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid2, "1", i.ToString());
+                if (i < 5)
+                {
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                    var raw = (TestEntity)res.Result;
+                    Assert.IsTrue(raw.a == 2 * i);
+                }
+                else
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid3, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i < 5)
+                {
+                    Assert.IsTrue(raw.a == 2 * i);
+                }
+                else
+                    Assert.IsTrue(raw.a == 3 * i);
+            }
+        }
+
+        [TestMethod]
+        public void BatchSingleOpTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            // test retrieve
+            var batch = new TableBatchOperation();
+            batch.Add(TableOperation.Retrieve<TestEntity>("1", "1"));
+            var retList = DoExecuteBatch(batch);
+            Assert.IsTrue(retList != null && retList.Count == 1);
+            Assert.IsTrue(retList[0] != null && retList[0].HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            // insert
+            var entity = new TestEntity("1", "1");
+            entity.a = 1;
+            entity.d = "Hello 1";
+
+            batch = new TableBatchOperation();
+            batch.Add(TableOperation.Insert(entity));
+
+            var resList1 = DoExecuteBatch(batch);
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 1);
+            Assert.IsTrue(resList1[0] != null && resList1[0].HttpStatusCode == (int)HttpStatusCode.Created);
+            Assert.IsTrue(resList1[0].Etag == entity.ETag);
+            Assert.IsTrue(entity.ETag.Contains(","));
+
+            var ssid0 = DoCreateSnapshot();
+
+            // test replace
+            batch = new TableBatchOperation();
+            entity.a = 2;
+            batch.Add(TableOperation.Replace(entity));
+
+            var resList2 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList2 != null && resList2.Count == 1);
+            Assert.IsTrue(resList2[0] != null && resList2[0].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            // test retrieve
+            batch = new TableBatchOperation();
+            batch.Add(TableOperation.Retrieve<TestEntity>(entity.PartitionKey, entity.RowKey));
+            retList = DoExecuteBatch(batch);
+            Assert.IsTrue(retList != null && retList.Count == 1);
+            Assert.IsTrue(retList[0] != null && retList[0].HttpStatusCode == (int)HttpStatusCode.OK && retList[0].Result != null);
+            var tup = (TestEntity)retList[0].Result;
+            Assert.IsTrue(tup.ETag == entity.ETag);
+            Assert.IsTrue(tup.a == 2);
+
+            var ssid1 = DoCreateSnapshot();
+
+            // test delete
+            batch = new TableBatchOperation();
+            batch.Add(TableOperation.Delete(entity));
+
+            var resList3 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList3 != null && resList3.Count == 1);
+            Assert.IsTrue(resList3[0] != null && resList3[0].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            // test retrieve
+            batch = new TableBatchOperation();
+            batch.Add(TableOperation.Retrieve<TestEntity>(entity.PartitionKey, entity.RowKey));
+            retList = DoExecuteBatch(batch);
+            Assert.IsTrue(retList != null && retList.Count == 1);
+            Assert.IsTrue(retList[0] != null && retList[0].HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+
+            var ssid2 = DoCreateSnapshot();
+
+            // test insert back
+            batch = new TableBatchOperation();
+            entity.a = 3;
+            batch.Add(TableOperation.Insert(entity));
+
+            var resList4 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList4 != null && resList4.Count == 1);
+            Assert.IsTrue(resList4[0] != null && resList4[0].HttpStatusCode == (int)HttpStatusCode.Created);
+
+            var ssid3 = DoCreateSnapshot();
+
+            // check
+            var res = DoRetrieveSnapshot(ssid0, "1", "1");
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+            var raw = (TestEntity)res.Result;
+            Assert.IsTrue(raw.a == 1);
+
+            res = DoRetrieveSnapshot(ssid1, "1", "1");
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+            raw = (TestEntity)res.Result;
+            Assert.IsTrue(raw.a == 2);
+
+            res = DoRetrieveSnapshot(ssid2, "1", "1");
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            res = DoRetrieveSnapshot(ssid3, "1", "1");
+            Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+            raw = (TestEntity)res.Result;
+            Assert.IsTrue(raw.a == 3);
+        }
+
+        [TestMethod]
+        public void BatchCOWOverDeletedSnapshotsTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            // insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+            }
+
+            var batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    batch.Add(TableOperation.Insert(entities[i]));
+                else if (i % 3 == 1)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList1 = DoExecuteBatch(batch);
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+                Assert.IsTrue(resList1[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid0 = DoCreateSnapshot();
+            var ssid1 = DoCreateSnapshot();
+
+            DoDeleteSnapshot(ssid0);
+
+            // test replace / merge / ior / iom, cow to ssid1
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 5; ++i)
+            {
+                entities[i].a = i * 2;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    batch.Add(TableOperation.Replace(entities[i]));
+                else if (i % 4 == 1)
+                    batch.Add(TableOperation.Merge(entities[i]));
+                else if (i % 4 == 2)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 4 == 3)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList2 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList2 != null && resList2.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList2[i] != null && resList2[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList2[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid2 = DoCreateSnapshot();
+
+            // test delete, 0-4 cow to ssid2, 5-9 skip ssid0 and cow to ssid1
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+                batch.Add(TableOperation.Delete(entities[i]));
+
+            var resList3 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList3 != null && resList3.Count == 10);
+            for (int i = 0; i < 10; ++i)
+                Assert.IsTrue(resList3[i] != null && resList3[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            var ssid3 = DoCreateSnapshot();
+
+            // test insert back, cow to ssid3
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i].a = i * 3;
+                entities[i].d = "wow!" + i.ToString();
+                entities[i].ETag = "";
+
+                if (i % 3 == 0)
+                    batch.Add(TableOperation.Insert(entities[i]));
+                else if (i % 3 == 1)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 3 == 2)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList4 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList4 != null && resList4.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if ((i) % 3 == 0)
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid4 = DoCreateSnapshot();
+
+            // replace / merge / ior / iom, cow to ssid4
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 5; ++i)
+            {
+                entities[i].a = i * 4;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    batch.Add(TableOperation.Replace(entities[i]));
+                else if (i % 4 == 1)
+                    batch.Add(TableOperation.Merge(entities[i]));
+                else if (i % 4 == 2)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 4 == 3)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList5 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList5 != null && resList5.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList5[i] != null && resList5[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList5[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid5 = DoCreateSnapshot();
+            DoDeleteSnapshot(ssid5);
+
+            // replace / merge / ior / iom, 0-4 do not cow since there is no valid ss at 5 (head = 6), 5-9 cow to ssid4
+            batch = new TableBatchOperation();
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i].a = i * 5;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    batch.Add(TableOperation.Replace(entities[i]));
+                else if (i % 4 == 1)
+                    batch.Add(TableOperation.Merge(entities[i]));
+                else if (i % 4 == 2)
+                    batch.Add(TableOperation.InsertOrReplace(entities[i]));
+                else if (i % 4 == 3)
+                    batch.Add(TableOperation.InsertOrMerge(entities[i]));
+            }
+
+            var resList6 = DoExecuteBatch(batch);
+            Assert.IsTrue(resList6 != null && resList6.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                Assert.IsTrue(resList6[i] != null && resList6[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList6[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+
+            // snapshot 0: not exist
+            // snapshot 1: initial state, 10 row with a = i
+            // snapshot 2: 1st state, 0-4 with a = 2*i, 5-9 missing (fall to ss1, a = i)
+            // snapshot 3: all deleted
+            // snapshot 4: all inserted with a = 3*i
+            // snapshot 5: not exist
+            // head: all with a = 5*i
+
+            var historyInfo = DoGetHistory();
+            Assert.IsTrue(historyInfo != null);
+            Assert.IsTrue(historyInfo.HeadSSID == 6);
+            Assert.IsTrue(historyInfo.Snapshots != null);
+            Assert.IsTrue(historyInfo.Snapshots.Count == 7);
+            for (int i = 0; i <= 6; ++i)
+            {
+                Assert.IsTrue(historyInfo.GetSnapshot(i) == historyInfo.Snapshots[i]);
+                Assert.IsTrue(historyInfo.Snapshots[i].SSID == i);
+            }
+
+            Assert.IsTrue(historyInfo.Snapshots[0].State == SnapshotState.Deleted);
+            Assert.IsTrue(historyInfo.Snapshots[0].Parent == SnapshotInfo.NoParent);
+            Assert.IsTrue(historyInfo.Snapshots[1].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[1].Parent == 0);
+            Assert.IsTrue(historyInfo.Snapshots[2].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[2].Parent == 1);
+            Assert.IsTrue(historyInfo.Snapshots[3].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[3].Parent == 2);
+            Assert.IsTrue(historyInfo.Snapshots[4].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[4].Parent == 3);
+            Assert.IsTrue(historyInfo.Snapshots[5].State == SnapshotState.Deleted);
+            Assert.IsTrue(historyInfo.Snapshots[5].Parent == 4);
+            Assert.IsTrue(historyInfo.Snapshots[6].State == SnapshotState.Head);
+            Assert.IsTrue(historyInfo.Snapshots[6].Parent == 5);
+
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid1, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid2, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i < 5)
+                    Assert.IsTrue(raw.a == 2 * i);
+                else
+                    Assert.IsTrue(raw.a == i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid3, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid4, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == 3 * i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == 5 * i);
+            }
+        }
+
+        [TestMethod]
+        public void SingleOpGeneralTest()
+        {
+            // same as BatchCOWOverDeletedSnapshot, use single op API
+
+            Assert.IsTrue(DoCreateTable());
+
+            // insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+            }
+
+            var resList1 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    resList1.Add(DoInsert(entities[i]));
+                else if (i % 3 == 1)
+                    resList1.Add(DoIOR(entities[i]));
+                else
+                    resList1.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+                Assert.IsTrue(resList1[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid0 = DoCreateSnapshot();
+            var ssid1 = DoCreateSnapshot();
+
+            DoDeleteSnapshot(ssid0);
+
+            // test replace / merge / ior / iom, cow to ssid1
+            var resList2 = new List<TableResult>();
+            for (int i = 0; i < 5; ++i)
+            {
+                entities[i].a = i * 2;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    resList2.Add(DoReplace(entities[i]));
+                else if (i % 4 == 1)
+                    resList2.Add(DoMerge(entities[i]));
+                else if (i % 4 == 2)
+                    resList2.Add(DoIOR(entities[i]));
+                else if (i % 4 == 3)
+                    resList2.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList2 != null && resList2.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList2[i] != null && resList2[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList2[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid2 = DoCreateSnapshot();
+
+            // test delete, 0-4 cow to ssid2, 5-9 skip ssid0 and cow to ssid1
+            var resList3 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+                resList3.Add(DoDelete(entities[i]));
+
+            Assert.IsTrue(resList3 != null && resList3.Count == 10);
+            for (int i = 0; i < 10; ++i)
+                Assert.IsTrue(resList3[i] != null && resList3[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            var ssid3 = DoCreateSnapshot();
+
+            // test insert back, cow to ssid3
+            var resList4 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i].a = i * 3;
+                entities[i].d = "wow!" + i.ToString();
+                entities[i].ETag = "";
+
+                if (i % 3 == 0)
+                    resList4.Add(DoInsert(entities[i]));
+                else if (i % 3 == 1)
+                    resList4.Add(DoIOR(entities[i]));
+                else if (i % 3 == 2)
+                    resList4.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList4 != null && resList4.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if ((i) % 3 == 0)
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid4 = DoCreateSnapshot();
+
+            // replace / merge / ior / iom, cow to ssid4
+            var resList5 = new List<TableResult>();
+            for (int i = 0; i < 5; ++i)
+            {
+                entities[i].a = i * 4;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    resList5.Add(DoReplace(entities[i]));
+                else if (i % 4 == 1)
+                    resList5.Add(DoMerge(entities[i]));
+                else if (i % 4 == 2)
+                    resList5.Add(DoIOR(entities[i]));
+                else if (i % 4 == 3)
+                    resList5.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList5 != null && resList5.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList5[i] != null && resList5[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList5[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            var ssid5 = DoCreateSnapshot();
+            DoDeleteSnapshot(ssid5);
+
+            // replace / merge / ior / iom, 0-4 do not cow since there is no valid ss at 5 (head = 6), 5-9 cow to ssid4
+            var resList6 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i].a = i * 5;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    resList6.Add(DoReplace(entities[i]));
+                else if (i % 4 == 1)
+                    resList6.Add(DoMerge(entities[i]));
+                else if (i % 4 == 2)
+                    resList6.Add(DoIOR(entities[i]));
+                else if (i % 4 == 3)
+                    resList6.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList6 != null && resList6.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                Assert.IsTrue(resList6[i] != null && resList6[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList6[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+
+            // snapshot 0: not exist
+            // snapshot 1: initial state, 10 row with a = i
+            // snapshot 2: 1st state, 0-4 with a = 2*i, 5-9 missing (fall to ss1, a = i)
+            // snapshot 3: all deleted
+            // snapshot 4: all inserted with a = 3*i
+            // snapshot 5: not exist
+            // head: all with a = 5*i
+
+            var historyInfo = DoGetHistory();
+            Assert.IsTrue(historyInfo != null);
+            Assert.IsTrue(historyInfo.HeadSSID == 6);
+            Assert.IsTrue(historyInfo.Snapshots != null);
+            Assert.IsTrue(historyInfo.Snapshots.Count == 7);
+            for (int i = 0; i <= 6; ++i)
+            {
+                Assert.IsTrue(historyInfo.GetSnapshot(i) == historyInfo.Snapshots[i]);
+                Assert.IsTrue(historyInfo.Snapshots[i].SSID == i);
+            }
+
+            Assert.IsTrue(historyInfo.Snapshots[0].State == SnapshotState.Deleted);
+            Assert.IsTrue(historyInfo.Snapshots[0].Parent == SnapshotInfo.NoParent);
+            Assert.IsTrue(historyInfo.Snapshots[1].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[1].Parent == 0);
+            Assert.IsTrue(historyInfo.Snapshots[2].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[2].Parent == 1);
+            Assert.IsTrue(historyInfo.Snapshots[3].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[3].Parent == 2);
+            Assert.IsTrue(historyInfo.Snapshots[4].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[4].Parent == 3);
+            Assert.IsTrue(historyInfo.Snapshots[5].State == SnapshotState.Deleted);
+            Assert.IsTrue(historyInfo.Snapshots[5].Parent == 4);
+            Assert.IsTrue(historyInfo.Snapshots[6].State == SnapshotState.Head);
+            Assert.IsTrue(historyInfo.Snapshots[6].Parent == 5);
+
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid1, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid2, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i < 5)
+                    Assert.IsTrue(raw.a == 2 * i);
+                else
+                    Assert.IsTrue(raw.a == i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid3, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid4, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == 3 * i);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == 5 * i);
+            }
+        }
+
+        [TestMethod]
+        public void RollbackGeneralTest()
+        {
+            // same as SingleOpGeneralTest, do not delete snapshots, add rollback
+
+            Assert.IsTrue(DoCreateTable());
+
+            // insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+            }
+
+            var resList1 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    resList1.Add(DoInsert(entities[i]));
+                else if (i % 3 == 1)
+                    resList1.Add(DoIOR(entities[i]));
+                else
+                    resList1.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+                Assert.IsTrue(resList1[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            string[] etagBackup0 = new string[10];
+            for (int i = 0; i < 10; ++i)
+                etagBackup0[i] = entities[i].ETag;
+
+            var ssid0 = DoCreateSnapshot();
+
+            // test replace / merge / ior / iom, cow to ssid0
+            var resList2 = new List<TableResult>();
+            for (int i = 0; i < 5; ++i)
+            {
+                entities[i].a = i * 2;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    resList2.Add(DoReplace(entities[i]));
+                else if (i % 4 == 1)
+                    resList2.Add(DoMerge(entities[i]));
+                else if (i % 4 == 2)
+                    resList2.Add(DoIOR(entities[i]));
+                else if (i % 4 == 3)
+                    resList2.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList2 != null && resList2.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList2[i] != null && resList2[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList2[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            string[] etagBackup1 = new string[10];
+            for (int i = 0; i < 10; ++i)
+                etagBackup1[i] = entities[i].ETag;
+
+            // rollback to ssid0
+            var ssid1 = DoRollback(ssid0);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == i && raw.ETag == etagBackup0[i]);
+                
+                entities[i].ETag = raw.ETag;
+            }
+
+            // test delete, cow to ssid1
+            var resList3 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+                resList3.Add(DoDelete(entities[i]));
+
+            Assert.IsTrue(resList3 != null && resList3.Count == 10);
+            for (int i = 0; i < 10; ++i)
+                Assert.IsTrue(resList3[i] != null && resList3[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var ret = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(ret != null && ret.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            // rollback the rollback, to ssid1
+
+            var ssid2 = DoRollback(ssid1);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.ETag == etagBackup1[i]);
+
+                if (i < 5)
+                    Assert.IsTrue(raw.a == 2 * i);
+                else
+                    Assert.IsTrue(raw.a == i);
+
+                entities[i].ETag = raw.ETag;
+            }
+
+            // insert a row
+            var newRow = new TestEntity("1", "10");
+            newRow.a = 999;
+            var newRowIns = DoInsert(newRow);
+            Assert.IsTrue(newRowIns != null && newRowIns.HttpStatusCode == (int)HttpStatusCode.Created);
+            var newRowETagBackup = newRow.ETag;
+
+            var ssid3 = DoCreateSnapshot();
+
+            // modify rows
+            var resList4 = new List<TableResult>();
+            for (int i = 5; i < 10; ++i)
+            {
+                entities[i].a = i * 4;
+                entities[i].b = i;
+
+                if (i % 4 == 0)
+                    resList4.Add(DoReplace(entities[i]));
+                else if (i % 4 == 1)
+                    resList4.Add(DoMerge(entities[i]));
+                else if (i % 4 == 2)
+                    resList4.Add(DoIOR(entities[i]));
+                else if (i % 4 == 3)
+                    resList4.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList4 != null && resList4.Count == 5);
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.IsTrue(resList4[i] != null && resList4[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+                Assert.IsTrue(resList4[i].Etag == entities[5 + i].ETag);
+                Assert.IsTrue(resList4[i].Etag.Contains(","));
+            }
+
+            string[] etagBackup4 = new string[10];
+            for (int i = 0; i < 10; ++i)
+                etagBackup4[i] = entities[i].ETag;
+
+            // rollback to ssid0 again, test deleting a row in rollback
+            var ssid4 = DoRollback(ssid0);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == i && raw.ETag == etagBackup0[i]);
+
+                entities[i].ETag = raw.ETag;
+            }
+            var newRowRet = DoRetrieve("1", "10");
+            Assert.IsTrue(newRowRet != null && newRowRet.HttpStatusCode == (int)HttpStatusCode.NotFound);
+
+            // rollback the rollback again, back to ssid4, test creating row in rollback
+            var ssid5 = DoRollback(ssid4);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieve("1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+
+                Assert.IsTrue(raw.ETag == etagBackup4[i]);
+
+                if (i < 5)
+                    Assert.IsTrue(raw.a == i * 2);
+                else
+                    Assert.IsTrue(raw.a == i * 4);
+
+                entities[i].ETag = raw.ETag;
+            }
+
+            newRowRet = DoRetrieve("1", "10");
+            Assert.IsTrue(newRowRet != null && newRowRet.HttpStatusCode == (int)HttpStatusCode.OK && newRowRet.Result != null);
+            var newRowData = (TestEntity)newRowRet.Result;
+            Assert.IsTrue(newRowData.ETag == newRowETagBackup && newRowData.a == 999);
+
+
+            // snapshot 0: initial state, 10 row with a = i
+            // snapshot 1: second state, 0-4 with a = 2*i, 5-9 with a = i
+            // snapshot 2: rollback to 0, then delete all rows
+            // snapshot 3: rollback to snapshot 1, 0-4 with a = 2*i, 5-9 with a = i, insert row 10 with a = 999
+            // snapshot 4: further update, 0-4 with a = 2*i, 5-9 with a = 4*i, 10 with a = 999
+            // snapshot 5: rollback to ss0, 10 row with a = i
+            // head (6): rollback to ss4
+
+            var historyInfo = DoGetHistory();
+            Assert.IsTrue(historyInfo != null);
+            Assert.IsTrue(historyInfo.HeadSSID == 6);
+            Assert.IsTrue(historyInfo.Snapshots != null);
+            Assert.IsTrue(historyInfo.Snapshots.Count == 7);
+            for (int i = 0; i <= 6; ++i)
+            {
+                Assert.IsTrue(historyInfo.GetSnapshot(i) == historyInfo.Snapshots[i]);
+                Assert.IsTrue(historyInfo.Snapshots[i].SSID == i);
+            }
+
+            Assert.IsTrue(historyInfo.Snapshots[0].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[0].Parent == SnapshotInfo.NoParent);
+            Assert.IsTrue(historyInfo.Snapshots[1].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[1].Parent == 0);
+            Assert.IsTrue(historyInfo.Snapshots[2].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[2].Parent == 0);
+            Assert.IsTrue(historyInfo.Snapshots[3].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[3].Parent == 1);
+            Assert.IsTrue(historyInfo.Snapshots[4].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[4].Parent == 3);
+            Assert.IsTrue(historyInfo.Snapshots[5].State == SnapshotState.Valid);
+            Assert.IsTrue(historyInfo.Snapshots[5].Parent == 0);
+            Assert.IsTrue(historyInfo.Snapshots[6].State == SnapshotState.Head);
+            Assert.IsTrue(historyInfo.Snapshots[6].Parent == 4);
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid0, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                Assert.IsTrue(raw.a == i);
+                Assert.IsTrue(raw.ETag == etagBackup0[i]);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid1, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i < 5)
+                    Assert.IsTrue(raw.a == 2 * i);
+                else
+                    Assert.IsTrue(raw.a == i);
+                Assert.IsTrue(raw.ETag == etagBackup1[i]);
+            }
+
+            for (int i = 0; i < 10; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid2, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+            }
+
+            for (int i = 0; i < 11; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid3, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i == 10)
+                {
+                    Assert.IsTrue(raw.a == 999 && raw.ETag == newRowETagBackup);
+                }
+                else
+                {
+                    if (i < 5)
+                        Assert.IsTrue(raw.a == 2 * i);
+                    else
+                        Assert.IsTrue(raw.a == i);
+                    Assert.IsTrue(raw.ETag == etagBackup1[i]);
+                }
+            }
+
+            for (int i = 0; i < 11; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid4, "1", i.ToString());
+                Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                var raw = (TestEntity)res.Result;
+                if (i == 10)
+                {
+                    Assert.IsTrue(raw.a == 999 && raw.ETag == newRowETagBackup);
+                }
+                else
+                {
+                    if (i < 5)
+                        Assert.IsTrue(raw.a == 2 * i);
+                    else
+                        Assert.IsTrue(raw.a == 4 * i);
+                    Assert.IsTrue(raw.ETag == etagBackup4[i]);
+                }
+            }
+
+            for (int i = 0; i < 11; ++i)
+            {
+                var res = DoRetrieveSnapshot(ssid5, "1", i.ToString());
+                if (i == 10)
+                {
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.NotFound);
+                }
+                else
+                {
+                    Assert.IsTrue(res != null && res.HttpStatusCode == (int)HttpStatusCode.OK && res.Result != null);
+                    var raw = (TestEntity)res.Result;
+                    Assert.IsTrue(raw.a == i && raw.ETag == etagBackup0[i]);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ConcurrentAccess()
+        {
+            int nUser = 20;
+            int nRow = 100;
+            int runTime = 90;
+
+            Assert.IsTrue(DoCreateTable());
+
+            Random r = new Random();
+            StreamWriter logger = new StreamWriter("d:/kiwi/debug.out", true);
+            logger.AutoFlush = true;
+
+            User[] users = new User[nUser];
+            for (int i = 0; i < nUser; ++i)
+                users[i] = new User(i, new STable(name, config, ts), nRow, logger, r.Next());
+
+            for (int i = 0; i < nUser; ++i)
+                users[i].Start();
+
+            Thread.Sleep(runTime * 1000);
+
+            for (int i = 0; i < nUser; ++i)
+                users[i].Stop();
+
+            for (int i = 0; i < nUser; ++i)
+                users[i].Join();
+
+            logger.Flush();
+            logger.Close();
+                
+        }
+
+        [TestMethod]
+        public void QueryAPIGeneralTest()
+        {
+            Assert.IsTrue(DoCreateTable());
+
+            // insert
+            TestEntity[] entities = new TestEntity[10];
+            for (int i = 0; i < 10; ++i)
+            {
+                entities[i] = new TestEntity("1", i.ToString());
+                entities[i].a = i;
+                entities[i].d = "hello" + i.ToString();
+            }
+
+            var resList1 = new List<TableResult>();
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    resList1.Add(DoInsert(entities[i]));
+                else if (i % 3 == 1)
+                    resList1.Add(DoIOR(entities[i]));
+                else
+                    resList1.Add(DoIOM(entities[i]));
+            }
+
+            Assert.IsTrue(resList1 != null && resList1.Count == 10);
+            for (int i = 0; i < 10; ++i)
+            {
+                if (i % 3 == 0)
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.Created);
+                else
+                    Assert.IsTrue(resList1[i] != null && resList1[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+                Assert.IsTrue(resList1[i].Etag == entities[i].ETag);
+                Assert.IsTrue(entities[i].ETag.Contains(","));
+            }
+
+            // Query all rows
+            var query = new TableQuery<TestEntity>();
+            var queryRes = DoQuery(query).OrderBy((x) => int.Parse(x.RowKey));
+            int qcnt = 0;
+            foreach (var qres in queryRes)
+            {
+                Assert.IsTrue(qcnt < 10);
+                Assert.IsTrue(qres.RowKey.Equals(entities[qcnt].RowKey));
+                Assert.IsTrue(qres.PartitionKey.Equals(entities[qcnt].PartitionKey));
+                Assert.IsTrue(qres.ETag.Equals(entities[qcnt].ETag));
+                Assert.IsTrue(qres.a == qcnt);
+                Assert.IsTrue(qres.d.Equals(entities[qcnt].d));
+                ++qcnt;
+            }
+            Assert.IsTrue(qcnt == 10);
+
+            // Query with filter
+            query = new TableQuery<TestEntity>().Where(TableQuery.GenerateFilterConditionForInt("a", QueryComparisons.LessThan, 5));
+            queryRes = DoQuery(query).OrderBy((x) => int.Parse(x.RowKey));
+            qcnt = 0;
+            foreach (var qres in queryRes)
+            {
+                Assert.IsTrue(qcnt < 5);
+                Assert.IsTrue(qres.RowKey.Equals(entities[qcnt].RowKey));
+                Assert.IsTrue(qres.PartitionKey.Equals(entities[qcnt].PartitionKey));
+                Assert.IsTrue(qres.ETag.Equals(entities[qcnt].ETag));
+                Assert.IsTrue(qres.a == qcnt);
+                Assert.IsTrue(qres.d.Equals(entities[qcnt].d));
+                ++qcnt;
+            }
+            Assert.IsTrue(qcnt == 5);
+
+            // Query with take
+            query = new TableQuery<TestEntity>().Where(TableQuery.GenerateFilterConditionForInt("a", QueryComparisons.LessThan, 5)).Take(3);
+            queryRes = DoQuery(query).OrderBy((x) => int.Parse(x.RowKey));
+            qcnt = 0;
+            int prevId = -1;
+            foreach (var qres in queryRes)
+            {
+                Assert.IsTrue(qcnt < 3);
+                Assert.IsTrue(int.Parse(qres.RowKey) > prevId);
+                prevId = int.Parse(qres.RowKey);
+
+                Assert.IsTrue(qres.RowKey.Equals(entities[prevId].RowKey));
+                Assert.IsTrue(qres.PartitionKey.Equals(entities[prevId].PartitionKey));
+                Assert.IsTrue(qres.ETag.Equals(entities[prevId].ETag));
+                Assert.IsTrue(qres.a == prevId);
+                Assert.IsTrue(qres.d.Equals(entities[prevId].d));
+                ++qcnt;
+            }
+            Assert.IsTrue(qcnt == 3);
+
+            // Do not test select(), since TestEntity requires all cols to exist
+
+            var ssid0 = DoCreateSnapshot();
+            var ssid1 = DoCreateSnapshot();
+
+            DoDeleteSnapshot(ssid0);
+
+            // test delete, 0-4 cow to ssid1
+            var resList3 = new List<TableResult>();
+            for (int i = 0; i < 5; ++i)
+                resList3.Add(DoDelete(entities[i]));
+
+            Assert.IsTrue(resList3 != null && resList3.Count == 5);
+            for (int i = 0; i < 5; ++i)
+                Assert.IsTrue(resList3[i] != null && resList3[i].HttpStatusCode == (int)HttpStatusCode.NoContent);
+
+            // Query all rows, check behavior with deleted rows
+            query = new TableQuery<TestEntity>();
+            queryRes = DoQuery(query).OrderBy((x) => int.Parse(x.RowKey));
+            qcnt = 0;
+            foreach (var qres in queryRes)
+            {
+                Assert.IsTrue(qcnt < 5);
+                Assert.IsTrue(qres.RowKey.Equals(entities[qcnt + 5].RowKey));
+                Assert.IsTrue(qres.PartitionKey.Equals(entities[qcnt + 5].PartitionKey));
+                Assert.IsTrue(qres.ETag.Equals(entities[qcnt + 5].ETag));
+                Assert.IsTrue(qres.a == qcnt + 5);
+                Assert.IsTrue(qres.d.Equals(entities[qcnt + 5].d));
+                ++qcnt;
+            }
+            Assert.IsTrue(qcnt == 5);
+        }
+
+
+
+
+        private string name;
+        private Random random = new Random();
+        private ISTableConfig config;
+        private IChainTableService ts;
+        private STable s;
+
+
+        private bool DoCreateTable()
+        {
+            return s.CreateIfNotExists();
+        }
+
+        private bool DoDeleteTable()
+        {
+            return s.DeleteIfExists();
+        }
+
+        private TableResult DoInsert(TestEntity entity)
+        {
+            return s.Execute(TableOperation.Insert(entity));
+        }
+
+        private TableResult DoRetrieve(string pKey, string rKey)
+        {
+            return s.Execute(TableOperation.Retrieve<TestEntity>(pKey, rKey));
+        }
+
+        private TableResult DoReplace(TestEntity entity)
+        {
+            return s.Execute(TableOperation.Replace(entity));
+        }
+
+        private TableResult DoMerge(ITableEntity entity)
+        {
+            return s.Execute(TableOperation.Merge(entity));
+        }
+
+        private TableResult DoDelete(TestEntity entity)
+        {
+            return s.Execute(TableOperation.Delete(entity));
+        }
+
+        private TableResult DoIOR(TestEntity entity)
+        {
+            return s.Execute(TableOperation.InsertOrReplace(entity));
+        }
+
+        private TableResult DoIOM(ITableEntity entity)
+        {
+            return s.Execute(TableOperation.InsertOrMerge(entity));
+        }
+
+        private IList<TableResult> DoExecuteBatch(TableBatchOperation batch)
+        {
+            return s.ExecuteBatch(batch);
+        }
+
+        private TableResult DoRetrieveSnapshot(int ssid, string pKey, string rKey)
+        {
+            return s.RetrieveFromSnapshot(TableOperation.Retrieve<TestEntity>(pKey, rKey), ssid);
+        }
+
+        private int DoCreateSnapshot()
+        {
+            return s.CreateSnapshot();
+        }
+
+        private void DoDeleteSnapshot(int ssid)
+        {
+            s.DeleteSnapshot(ssid);
+        }
+
+        private int DoRollback(int ssid)
+        {
+            return s.Rollback(ssid);
+        }
+
+        private void DoGC()
+        {
+            s.GC();
+        }
+
+        private IEnumerable<TestEntity> DoQuery(TableQuery<TestEntity> q)
+        {
+            return s.ExecuteQuery(q);
+        }
+
+        private STableHistoryInfo DoGetHistory()
+        {
+            return s.GetSTableHistory();
+        }
+    }
+}

--- a/stable/STableUnitTest/User.cs
+++ b/stable/STableUnitTest/User.cs
@@ -1,0 +1,406 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.WindowsAzure.Storage;
+using Microsoft.WindowsAzure.Storage.ChainTableInterface;
+using Microsoft.WindowsAzure.Storage.STable;
+using Microsoft.WindowsAzure.Storage.Table;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace STableUnitTest
+{
+    class User
+    {
+        public User(int id, STable s, int nRow, TextWriter logger, int seed)
+        {
+            this.id = id;
+            this.s = s;
+            this.nRow = nRow;
+            this.logger = logger;
+
+            r = new Random(seed);
+        }
+
+        public void Start()
+        {
+            running = true;
+            opId = 0;
+            t = new Thread(new ThreadStart(Run));
+            t.Start();
+        }
+
+        public void Stop()
+        {
+            logger.WriteLine("Stopping user " + id + ".");
+            running = false;
+        }
+
+        public void Join()
+        {
+            t.Join();
+        }
+
+
+
+        private int id;
+        private STable s;
+        private int nRow;
+
+        private Thread t;
+        private bool running;
+        private int opId;
+
+        private Random r;
+        private TextWriter logger;
+
+
+
+        private void Run()
+        {
+            logger.WriteLine("User " + id + " started.");
+
+            try
+            {
+                while (running)
+                {
+                    ++opId;
+
+                    int rnd = r.Next(100);
+                    if (rnd < 5)
+                    {
+                        try
+                        {
+                            var res = DoCreateSnapshot();
+                            logger.WriteLine("Created snapshot " + res);
+                        }
+                        catch (StorageException e)
+                        {
+                            logger.WriteLine("Warning: Create snapshot returns " + e.RequestInformation.HttpStatusCode);
+                        }
+                    }
+                    else if (rnd < 20)
+                    {
+                        int key = r.Next(nRow);
+                        string pKey = GetPKey(key);
+                        string rKey = key.ToString();
+
+                        var ssids = DoListSnapshots();
+
+                        if (ssids.Count > 0)
+                        {
+                            var ssid = ssids[r.Next(ssids.Count)];
+
+                            try
+                            {
+                                var res = DoRetrieveSnapshot(ssid, pKey, rKey);
+
+                                Assert.IsTrue(res != null);
+                                if (res.HttpStatusCode == (int)HttpStatusCode.OK)
+                                {
+                                    Assert.IsTrue(res.Result != null && res.Result is TestEntity);
+                                    var ent = (TestEntity)res.Result;
+
+                                    PrintEntity(ssid, rKey, ent);
+                                }
+                                else if (res.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                                    PrintEntity(ssid, rKey, null);
+                                else
+                                    Assert.IsTrue(false);
+                            }
+                            catch (StorageException e)
+                            {
+                                logger.WriteLine("Warning: retrieve history returns " + e.RequestInformation.HttpStatusCode);
+                            }
+                        }
+                    }
+                    else if (rnd < 80)
+                    {
+                        int key = r.Next(nRow);
+                        string pKey = GetPKey(key);
+                        string rKey = key.ToString();
+
+                        var currState = DoRetrieve(pKey, rKey);
+                        Assert.IsTrue(currState != null);
+                        if (currState.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                        {
+                            TestEntity newEnt = new TestEntity(pKey, rKey);
+                            newEnt.a = id;
+                            newEnt.b = opId;
+
+                            int op = r.Next(3);
+
+                            if (op == 0)
+                                ExecInsert(newEnt);
+                            else if (op == 1)
+                                ExecIOR(newEnt);
+                            else
+                                ExecIOM(newEnt);
+                        }
+                        else if (currState.HttpStatusCode == (int)HttpStatusCode.OK)
+                        {
+                            Assert.IsTrue(currState.Result != null && currState.Result is TestEntity);
+                            var ent = (TestEntity)currState.Result;
+                            int op = r.Next(5);
+
+                            if (op == 0)
+                                ExecDelete(ent);
+                            else
+                            {
+                                ent.a = id;
+                                ent.b = opId;
+
+                                if (op == 1)
+                                    ExecIOR(ent);
+                                else if (op == 2)
+                                    ExecIOM(ent);
+                                else if (op == 3)
+                                    ExecReplace(ent);
+                                else
+                                    ExecMerge(ent);
+                            }
+                        }
+                        else
+                            logger.WriteLine("Warning: Retrieve returns " + currState.HttpStatusCode);
+                    }
+                    else
+                    {
+                        int batchSize = 3;
+                        int targetPKey = r.Next(10);
+                        List<int> keys = GenerateRows(targetPKey, batchSize);
+                        var batch = new TableBatchOperation();
+
+                        for (int i = 0; i < batchSize; ++i)
+                        {
+                            string pKey = GetPKey(keys[i]);
+                            string rKey = keys[i].ToString();
+
+                            var currState = DoRetrieve(pKey, rKey);
+                            Assert.IsTrue(currState != null);
+                            if (currState.HttpStatusCode == (int)HttpStatusCode.NotFound)
+                            {
+                                TestEntity newEnt = new TestEntity(pKey, rKey);
+                                newEnt.a = id;
+                                newEnt.b = opId;
+                                batch.Add(TableOperation.Insert(newEnt));
+                            }
+                            else if (currState.HttpStatusCode == (int)HttpStatusCode.OK)
+                            {
+                                Assert.IsTrue(currState.Result != null && currState.Result is TestEntity);
+                                var ent = (TestEntity)currState.Result;
+                                int op = r.Next(5);
+
+                                if (op == 0)
+                                    batch.Add(TableOperation.Delete(ent));
+                                else
+                                {
+                                    ent.a = id;
+                                    ent.b = opId;
+
+                                    if (op == 1)
+                                        batch.Add(TableOperation.InsertOrReplace(ent));
+                                    else if (op == 2)
+                                        batch.Add(TableOperation.InsertOrMerge(ent));
+                                    else if (op == 3)
+                                        batch.Add(TableOperation.Replace(ent));
+                                    else
+                                        batch.Add(TableOperation.Merge(ent));
+                                }
+                            }
+                            else
+                                logger.WriteLine("Warning: Retrieve returns " + currState.HttpStatusCode);
+                        }
+
+                        ExecBatch(batch);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(e.StackTrace);
+                Assert.IsTrue(false);
+            }
+
+            logger.WriteLine("User " + id + " stopped.");
+        }
+
+        private List<int> GenerateRows(int targetPKey, int n)
+        {
+            Assert.IsTrue(n <= nRow / 20);
+
+            var res = new List<int>();
+            for (int i = 0; i < n; ++i)
+            {
+                int t = r.Next(nRow) / 10 * 10 + targetPKey;
+                while (res.Contains(t))
+                    t = r.Next(nRow) / 10 * 10 + targetPKey;
+
+                res.Add(t);
+            }
+
+            return res;
+        }
+
+        private void PrintEntity(int ssid, string rkey, TestEntity ent)
+        {
+            StringBuilder sb = new StringBuilder();
+            if (ssid != null)
+                sb.Append("ssid = " + ssid);
+            else
+                sb.Append("ssid = h");
+
+            sb.Append(", row = " + rkey);
+
+            if (ent == null)
+                sb.Append(", content = NotFound");
+            else
+                sb.Append(", content = {a = " + ent.a + ", b = " + ent.b + "}");
+
+            logger.WriteLine(sb.ToString());
+        }
+
+
+        private string GetPKey(int rKey)
+        {
+            return (rKey % 10).ToString();
+        }
+
+        private TableResult DoRetrieve(string pKey, string rKey)
+        {
+            return s.Execute(TableOperation.Retrieve<TestEntity>(pKey, rKey));
+        }
+
+        private TableResult DoRetrieveSnapshot(int ssid, string pKey, string rKey)
+        {
+            return s.RetrieveFromSnapshot(TableOperation.Retrieve<TestEntity>(pKey, rKey), ssid);
+        }
+
+        private void ExecInsert(TestEntity entity)
+        {
+            try
+            {
+                var res = s.Execute(TableOperation.Insert(entity));
+                Assert.IsTrue(res != null);
+                Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.Created);
+            }
+            catch (StorageException e)
+            {
+                logger.WriteLine("Warning: Insert returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private void ExecReplace(TestEntity entity)
+        {
+            try
+            {
+                var res = s.Execute(TableOperation.Replace(entity));
+                Assert.IsTrue(res != null);
+                Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            }
+            catch (StorageException e)
+            {
+                logger.WriteLine("Warning: Replace returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private void ExecMerge(ITableEntity entity)
+        {
+            try
+            {
+                var res = s.Execute(TableOperation.Merge(entity));
+                Assert.IsTrue(res != null);
+                Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            }
+            catch (StorageException e)
+            {
+                logger.WriteLine("Warning: Merge returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private void ExecDelete(TestEntity entity)
+        {
+            try
+            {
+                var res = s.Execute(TableOperation.Delete(entity));
+                Assert.IsTrue(res != null);
+                Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            }
+            catch (StorageException e)
+            {
+                logger.WriteLine("Warning: Delete returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private void ExecIOR(TestEntity entity)
+        {
+            try
+            {
+                var res = s.Execute(TableOperation.InsertOrReplace(entity));
+                Assert.IsTrue(res != null);
+                Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            }
+            catch (StorageException e)
+            {
+                logger.WriteLine("Warning: IOR returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private void ExecIOM(ITableEntity entity)
+        {
+            try
+            {
+                var res = s.Execute(TableOperation.InsertOrMerge(entity));
+                Assert.IsTrue(res != null);
+                Assert.IsTrue(res.HttpStatusCode == (int)HttpStatusCode.NoContent);
+            }
+            catch (StorageException e)
+            {
+                logger.WriteLine("Warning: IOM returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private void ExecBatch(TableBatchOperation batch)
+        {
+            try
+            {
+                var res = s.ExecuteBatch(batch);
+
+                Assert.IsTrue(res != null && res.Count == batch.Count);
+                for (int i = 0; i < res.Count; ++i)
+                {
+                    Assert.IsTrue(res[i] != null && (res[i].HttpStatusCode == (int)HttpStatusCode.Created ||
+                        res[i].HttpStatusCode == (int)HttpStatusCode.NoContent));
+                }
+            }
+            catch (StorageException e)
+            {
+                Assert.IsTrue(e is ChainTableBatchException);
+                logger.WriteLine("Warning: batch returns " + e.RequestInformation.HttpStatusCode);
+            }
+        }
+
+        private IList<int> DoListSnapshots()
+        {
+            return s.ListValidSnapshots();
+        }
+
+        private int DoCreateSnapshot()
+        {
+            return s.CreateSnapshot();
+        }
+
+        private void DoDeleteSnapshot(int ssid)
+        {
+            s.DeleteSnapshot(ssid);
+        }
+
+        private int DoRollback(int ssid)
+        {
+            return s.Rollback(ssid);
+        }
+    }
+}

--- a/stable/STableUnitTest/app.config
+++ b/stable/STableUnitTest/app.config
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.Edm" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.Data.OData" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Spatial" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.0.0" newVersion="5.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-6.1.0.0" newVersion="6.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/stable/STableUnitTest/packages.config
+++ b/stable/STableUnitTest/packages.config
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net45" />
+  <package id="Microsoft.Data.Edm" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.OData" version="5.6.4" targetFramework="net45" />
+  <package id="Microsoft.Data.Services.Client" version="5.6.4" targetFramework="net45" />
+  <package id="Newtonsoft.Json" version="6.0.8" targetFramework="net45" />
+  <package id="System.Spatial" version="5.6.4" targetFramework="net45" />
+  <package id="WindowsAzure.Storage" version="6.1.0" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
Hello, Here is a patch that enables batch operations in RTable in the presence of using essentially the same mechanisms that were used for a single operations. I have only done basic testing. We need to test this in a staging environment. We can discuss this more on email or in a Skype call.

Thanks!
Srinath