### PR TITLE
Changes to fix Staleview exceptions in 2 different scenarios

### DIFF
--- a/library/CloudBlobHelpers.cs
+++ b/library/CloudBlobHelpers.cs
@@ -134,7 +134,8 @@ namespace Microsoft.Azure.Toolkit.Replication
         {
             try
             {
-                string content = await blob.DownloadTextAsync(ct);
+                BlobRequestOptions options = new BlobRequestOptions() { ServerTimeout = TimeSpan.FromSeconds(30) };
+                string content = await blob.DownloadTextAsync(null, null, options, null, ct);
                 if (content == Constants.ConfigurationStoreUpdatingText)
                 {
                     return new ReplicatedTableReadBlobResult(ReadBlobCode.UpdateInProgress, "Blob update in progress ...");

--- a/library/ReplicatedTableConfigurationManager.cs
+++ b/library/ReplicatedTableConfigurationManager.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Toolkit.Replication
         {
             get
             {
-                return Math.Max(((int)LeaseDuration.TotalSeconds / 2 - Constants.MinimumLeaseRenewalInterval), Constants.MinimumLeaseRenewalInterval);
+                return Math.Max(((int)LeaseDuration.TotalSeconds / 3 - Constants.MinimumLeaseRenewalInterval), Constants.MinimumLeaseRenewalInterval);
             }
         }
 


### PR DESCRIPTION
Fixes for 2 issues
1. When IgnoreHigherViewIdRows is set to false we are still getting view exception errors
2. Sometimes calls to blob take too long and dont timeout resulting staleview.